### PR TITLE
Install Package[python-software-properties] only if not already defined

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,8 +26,10 @@ class nodejs {
     'Ubuntu': {
       class { 'apt': }
 
-      package { 'python-software-properties':
-        ensure => present,
+      if !defined(Package["python-software-properties"]) {
+        package { 'python-software-properties':
+          ensure => present,
+        }
       }
 
       apt::ppa { 'ppa:chris-lea/node.js':


### PR DESCRIPTION
This was needed to interoperate correctly with: (puppet-apt)[https://github.com/puppetlabs/puppet-apt]

I copied this fix from another pull request to both puppet-apt and puppet-mongodb.

**Error I received received WITHOUT this fix:**

```
Duplicate definition: Package[python-software-properties] is already defined in file /tmp/vagrant-puppet/modules-0/apt/manifests/init.pp at line 41; cannot redefine at /tmp/vagrant-puppet/modules-0/nodejs/manifests/init.pp:31 on node ubuntu-oneiric.sd.cox.net
```
