### PR TITLE
fix .travis.yml for the apt module repo rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: ruby
 rvm:
   - 1.8.7
 before_script:
-  - "git clone git://github.com/puppetlabs/puppet-apt.git spec/fixtures/modules/apt && git clone git://github.com/puppetlabs/puppetlabs-stdlib.git spec/fixtures/modules/stdlib"
+  - "git clone git://github.com/puppetlabs/puppetlabs-apt.git spec/fixtures/modules/apt
+  - "git clone git://github.com/puppetlabs/puppetlabs-stdlib.git spec/fixtures/modules/stdlib"
 after_script:
 script: "rake spec"
 branches:


### PR DESCRIPTION
The apt module has moved from puppet-apt to puppetlabs-apt. This patch fixes the travis config to match that change.
