### PR TITLE
Add support for npm proxy configuration.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,8 @@
 # Usage:
 #
 class nodejs(
-  $dev_package = false
+  $dev_package = false,
+  $proxy       = ''
 ) inherits nodejs::params {
 
   case $::operatingsystem {
@@ -65,6 +66,14 @@ class nodejs(
     name    => $nodejs::params::npm_pkg,
     ensure  => present,
     require => Anchor['nodejs::repo']
+  }
+
+  if $proxy {
+    exec { 'npm_proxy':
+      command => "npm config set proxy ${proxy}",
+      path    => $::path,
+      require => Package['npm'],
+    }
   }
 
   if $dev_package and $nodejs::params::dev_pkg {

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -43,6 +43,9 @@ define nodejs::npm (
       path    => $::path,
       require => Class['nodejs'],
     }
+
+    # Conditionally require npm_proxy only if resource exists.
+    Exec<| title=='npm_proxy' |> -> Exec["npm_install_${name}"]
   } else {
     exec { "npm_remove_${name}":
       command => "npm remove ${npm_pkg}",

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -33,6 +33,10 @@ describe 'nodejs', :type => :class do
       }
     end
 
+    let :params do
+      { :dev_package => true, }
+    end
+
     it { should contain_class('apt') }
     it { should contain_apt__ppa('ppa:chris-lea/node.js') }
     it { should contain_package('nodejs') }
@@ -40,6 +44,7 @@ describe 'nodejs', :type => :class do
       'name'    => 'nodejs',
       'require' => 'Anchor[nodejs::repo]',
     }) }
+    it { should contain_package('nodejs-dev') }
     it { should contain_package('npm').with({
       'name'    => 'npm',
       'require' => 'Anchor[nodejs::repo]',
@@ -76,5 +81,29 @@ describe 'nodejs', :type => :class do
       it { should_not contain_package('nodejs-dev') }
     end
   end
+
+  describe 'when deploying with proxy' do
+    let :facts do
+      {
+        :operatingsystem => 'Ubuntu',
+        :lsbdistcodename => 'edgy',
+      }
+    end
+
+    let :params do
+      { :proxy => 'http://proxy.puppetlabs.lan:80/' }
+    end
+
+    it { should contain_package('npm').with({
+      'name'    => 'npm',
+      'require' => 'Anchor[nodejs::repo]',
+    }) }
+    it { should contain_exec('npm_proxy').with({
+      'command' => 'npm config set proxy http://proxy.puppetlabs.lan:80/',
+      'require' => 'Package[npm]',
+    }) }
+    it { should_not contain_package('nodejs-stable-release') }
+  end
+
 end
 


### PR DESCRIPTION
Add npm proxy support and configuration of proxy prior to installing npm
packages. Without this support npm install <package> will error:

```
npm ERR! Error: failed to fetch from registry: <package>
```
