### PR TITLE
Allow the pkg_src to be overriden on the main class

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Install nodejs package and npm package provider for Debian, Ubuntu, Fedora, and 
 Installs nodejs and npm per [nodejs documentation](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
 
 * dev_package: whether to install optional dev packages. dev packages not available on all platforms, default: false.
+* pkg_src: A url for a repo release package used on RedHat based systems to setup a yum repo.
 
 Example:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,8 @@
 #
 class nodejs(
   $dev_package = false,
-  $proxy       = ''
+  $proxy       = '',
+  $pkg_src     = ''
 ) inherits nodejs::params {
 
   case $::operatingsystem {
@@ -40,9 +41,14 @@ class nodejs(
     }
 
     'Fedora', 'RedHat', 'CentOS', 'Amazon': {
+      $r_pkg_src = $pkg_src ? {
+        ''      => $nodejs::params::pkg_src,
+        default => $pkg_src
+      }
+
       package { 'nodejs-stable-release':
         ensure   => present,
-        source   => $nodejs::params::pkg_src,
+        source   => $r_pkg_src,
         provider => 'rpm',
         before   => Anchor['nodejs::repo'],
       }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -105,5 +105,21 @@ describe 'nodejs', :type => :class do
     it { should_not contain_package('nodejs-stable-release') }
   end
 
+  describe 'when pkg_src is specified' do
+    let :facts do 
+      {
+        :operatingsystem => 'RedHat'
+      }
+    end
+
+    let :params do
+      {
+        :pkg_src => 'http://pkg.puppetlabs.com/nodejs-release.noarch.rpm'
+      }
+    end
+    it { should contain_package('nodejs-stable-release').with({
+      'source' => 'http://pkg.puppetlabs.com/nodejs-release.noarch.rpm'
+    }) }
+  end
 end
 


### PR DESCRIPTION
I would like to be able to set a different pkg_src for the RedHat repos since I mirror repos internally for various reasons.  Attached is code that would allow that to be set as a parameter on the class.
