### PR TITLE
add new parameter for the version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,8 @@
 #
 class nodejs(
   $dev_package = false,
-  $proxy       = ''
+  $proxy       = '',
+  $version     = 'present'
 ) inherits nodejs::params {
 
   case $::operatingsystem {
@@ -79,7 +80,7 @@ class nodejs(
   if $dev_package and $nodejs::params::dev_pkg {
     package { 'nodejs-dev':
       name    => $nodejs::params::dev_pkg,
-      ensure  => present,
+      ensure  => $version,
       require => Anchor['nodejs::repo']
     }
   }


### PR DESCRIPTION
Sometimes it is usefu to specify a version when installing the package (for instance, to upgrade to a new version or just to avoid getting a different version when building another server after some time)
