### PR TITLE
added +manage_repository+ parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,54 +9,57 @@
 # Usage:
 #
 class nodejs(
-  $dev_package = false,
-  $proxy       = ''
+  $dev_package       = false,
+  $proxy             = '',
+  $manage_repository = true
 ) inherits nodejs::params {
 
-  case $::operatingsystem {
-    'Debian': {
-      include 'apt'
+  if $manage_repository {
+    case $::operatingsystem {
+      'Debian': {
+        include 'apt'
 
-      apt::source { 'sid':
-        location    => 'http://ftp.us.debian.org/debian/',
-        release     => 'sid',
-        repos       => 'main',
-        pin         => 100,
-        include_src => false,
-        before      => Anchor['nodejs::repo'],
+        apt::source { 'sid':
+          location    => 'http://ftp.us.debian.org/debian/',
+          release     => 'sid',
+          repos       => 'main',
+          pin         => 100,
+          include_src => false,
+          before      => Anchor['nodejs::repo'],
+        }
+
       }
 
-    }
+      'Ubuntu': {
+        include 'apt'
 
-    'Ubuntu': {
-      include 'apt'
-
-      # Only use PPA when necessary.
-      if $::lsbdistcodename != 'Precise'{
-        apt::ppa { 'ppa:chris-lea/node.js':
-          before => Anchor['nodejs::repo'],
+        # Only use PPA when necessary.
+        if $::lsbdistcodename != 'Precise'{
+          apt::ppa { 'ppa:chris-lea/node.js':
+            before => Anchor['nodejs::repo'],
+          }
         }
       }
-    }
 
-    'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon': {
-      package { 'nodejs-stable-release':
-        ensure => absent,
-        before => Yumrepo['nodejs-stable'],
+      'Fedora', 'RedHat', 'CentOS', 'OEL', 'OracleLinux', 'Amazon': {
+        package { 'nodejs-stable-release':
+          ensure => absent,
+          before => Yumrepo['nodejs-stable'],
+        }
+
+        yumrepo { 'nodejs-stable':
+          descr    => 'Stable releases of Node.js',
+          baseurl  => $nodejs::params::baseurl,
+          enabled  => 1,
+          gpgcheck => $nodejs::params::gpgcheck,
+          gpgkey   => 'http://patches.fedorapeople.org/oldnode/stable/RPM-GPG-KEY-tchol',
+          before   => Anchor['nodejs::repo'],
+        }
       }
 
-      yumrepo { 'nodejs-stable':
-        descr    => 'Stable releases of Node.js',
-        baseurl  => $nodejs::params::baseurl,
-        enabled  => 1,
-        gpgcheck => $nodejs::params::gpgcheck,
-        gpgkey   => 'http://patches.fedorapeople.org/oldnode/stable/RPM-GPG-KEY-tchol',
-        before   => Anchor['nodejs::repo'],
+      default: {
+        fail("Class nodejs does not support ${::operatingsystem}")
       }
-    }
-
-    default: {
-      fail("Class nodejs does not support ${::operatingsystem}")
     }
   }
 


### PR DESCRIPTION
Often there is a security role preventing somebody to connect to
external repositories. This is not necessary anymore and also self
build packages can be used.
