### PR TITLE
Fix to install failure's on Ubuntu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,10 @@ class nodejs(
             before => Anchor['nodejs::repo'],
           }
         }
+
+        apt::ppa { 'ppa:chris-lea/node.js-devel':
+          before => Anchor['nodejs::repo'],
+        }
       }
     }
 

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -75,6 +75,10 @@ describe 'nodejs', :type => :class do
         should_not contain_apt__ppa('ppa:chris-lea/node.js')
       end
     end
+
+    it { should contain_class('apt') }
+    it { should contain_apt__ppa('ppa:chris-lea/node.js') }
+    it { should contain_apt__ppa('ppa:chris-lea/node.js-devel') }
     it { should contain_package('nodejs') }
     it { should contain_package('nodejs').with({
       'name'    => 'nodejs',


### PR DESCRIPTION
Hi.

As described here: https://chrislea.com/2013/03/15/upgrading-from-node-js-0-8-x-to-0-10-0-from-my-ppa/, the node.js package in Chris Lea's PPA now contains npm. Requiring npm separately causes Ubuntu to fallback to it's own packaged version, which requires an earlier version of node.js. This patch causes the npm package to not be required if using Chris's PPA.
