### PR TITLE
Workaround for node-gyp environment issue

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -5,7 +5,10 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
   has_feature :versionable
 
-  optional_commands :npm => 'npm'
+  has_command(:npm, 'npm') do
+      is_optional
+      environment :HOME => '/root'
+  end
 
   def self.npmlist
     begin


### PR DESCRIPTION
When $HOME is not set, using node v0.10 and the NPM provider,
this issue will be triggered:
- https://github.com/TooTallNate/node-gyp/issues/21
