### PR TITLE
allow optional install of npm package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,11 +12,13 @@ class nodejs(
   $dev_package = false,
   $manage_repo = false,
   $proxy       = '',
-  $version     = 'present'
+  $version     = 'present',
+  $install_npm = $nodejs::params::install_npm,
 ) inherits nodejs::params {
   #input validation
   validate_bool($dev_package)
   validate_bool($manage_repo)
+  validate_bool($install_npm)
 
   case $::operatingsystem {
     'Debian': {
@@ -89,9 +91,7 @@ class nodejs(
     require => Anchor['nodejs::repo']
   }
 
-  if $::operatingsystem != 'ubuntu' {
-    # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
-    # we must not install it separately
+  if $install_npm {
     package { 'npm':
       name    => $nodejs::params::npm_pkg,
       ensure  => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,12 +15,22 @@ class nodejs::params {
       $node_pkg = 'nodejs'
       $npm_pkg  = 'npm'
       $dev_pkg  = 'nodejs-dev'
+
+      # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
+      # we must not install it separately
+      if $::operatingsystem == 'ubuntu' {
+        $install_npm = false
+      } else {
+        $install_npm = true
+      }
+
     }
 
     'SLES', 'OpenSuSE': {
       $node_pkg = 'nodejs'
       $npm_pkg  = 'npm'
       $dev_pkg  = 'nodejs-devel'
+      $install_npm = true
     }
 
     'RedHat', 'CentOS', 'OEL', 'OracleLinux': {
@@ -39,22 +49,25 @@ class nodejs::params {
           $node_pkg = 'nodejs'
         }
       }
-      $npm_pkg  = 'npm'
-      $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/el$releasever/$basearch/'
+      $npm_pkg     = 'npm'
+      $baseurl     = 'http://patches.fedorapeople.org/oldnode/stable/el$releasever/$basearch/'
+      $install_npm = true
     }
 
     'Fedora': {
-      $node_pkg = 'nodejs-compat-symlinks'
-      $npm_pkg  = 'npm'
-      $gpgcheck = 1
-      $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/f$releasever/$basearch/'
+      $node_pkg    = 'nodejs-compat-symlinks'
+      $npm_pkg     = 'npm'
+      $gpgcheck    = 1
+      $baseurl     = 'http://patches.fedorapeople.org/oldnode/stable/f$releasever/$basearch/'
+      $install_npm = true
     }
 
     'Amazon': {
-      $node_pkg = 'nodejs-compat-symlinks'
-      $npm_pkg  = 'npm'
-      $gpgcheck = 1
-      $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/amzn1/$basearch/'
+      $node_pkg    = 'nodejs-compat-symlinks'
+      $npm_pkg     = 'npm'
+      $gpgcheck    = 1
+      $baseurl     = 'http://patches.fedorapeople.org/oldnode/stable/amzn1/$basearch/'
+      $install_npm = true
     }
 
     default: {

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -240,5 +240,19 @@ describe 'nodejs', :type => :class do
     }) }
 
   end
+
+  describe 'when not deploying with npm' do
+    let :facts do
+      {
+        :operatingsystem => 'Fedora'
+      }
+    end
+
+    let :params do
+      { :install_npm => false }
+    end
+
+    it { should_not contain_package('npm') }
+  end
 end
 


### PR DESCRIPTION
We have a custom nodejs package built that includes npm (and isn't Ubuntu) and so need to not attempt to install the npm package.  Moved the ubuntu conditional to params, defaults for all OSes remains the same.
