### PR TITLE
Changed Amazon package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class nodejs::params {
     }
 
     'Amazon': {
-      $node_pkg = 'nodejs-compat-symlinks'
+      $node_pkg = 'nodejs'
       $npm_pkg  = 'npm'
       $gpgcheck = 1
       $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/amzn1/$basearch/'


### PR DESCRIPTION
On Amazon Linux with Epel activate nodejs-compat-symlinks is not present anymore, but nodejs instead
