### PR TITLE
Fix ubuntu development package being installed when dev flag is set to false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,8 +43,10 @@ class nodejs(
           before => Anchor['nodejs::repo'],
         }
 
-        apt::ppa { 'ppa:chris-lea/node.js-devel':
-          before => Anchor['nodejs::repo'],
+        if $dev_package {
+            apt::ppa { 'ppa:chris-lea/node.js-devel':
+              before => Anchor['nodejs::repo'],
+            }
         }
       }
     }


### PR DESCRIPTION
Was including the development (unstable) even when flag was false.
puppetlabs/puppetlabs-nodejs#62 hasn't been merged yet... so...
