### PR TITLE
install nodejs and npm on gentoo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
+    "portage": "git://github.com/gentoo/puppet-portage.git"
   symlinks:
     "nodejs": "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,10 @@ class nodejs(
       }
     }
 
+    'Gentoo': {
+      # Gentoo does not need any special repos for nodejs
+    }
+
     default: {
       fail("Class nodejs does not support ${::operatingsystem}")
     }
@@ -91,13 +95,29 @@ class nodejs(
     require => Anchor['nodejs::repo']
   }
 
-  if $::operatingsystem != 'Ubuntu' {
-    # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
-    # we must not install it separately
-    package { 'npm':
-      name    => $nodejs::params::npm_pkg,
-      ensure  => present,
-      require => Anchor['nodejs::repo']
+  case $::operatingsystem {
+    'Ubuntu': {
+      # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
+      # we must not install it separately
+    }
+
+    'Gentoo': {
+      # Gentoo installes npm with the nodejs package when configured properly.
+      # We use the gentoo/portage module since it is expected to be
+      # available on all gentoo installs.
+      package_use { $nodejs::params::node_pkg:
+        ensure  => present,
+        use     => 'npm',
+        require => Anchor['nodejs::repo'],
+      }
+    }
+
+    default: {
+      package { 'npm':
+        name    => $nodejs::params::npm_pkg,
+        ensure  => present,
+        require => Anchor['nodejs::repo']
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,10 @@ class nodejs::params {
       $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/amzn1/$basearch/'
     }
 
+    'Gentoo': {
+      $node_pkg = 'net-libs/nodejs'
+    }
+
     default: {
       fail("Class nodejs does not support ${::operatingsystem}")
     }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -246,5 +246,24 @@ describe 'nodejs', :type => :class do
     }) }
 
   end
+
+  describe 'when deploying on gentoo' do
+    let :facts do
+      {
+        :operatingsystem => 'Gentoo',
+      }
+    end
+
+    it { should contain_package_use('net-libs/nodejs').with({
+      'ensure'  => 'present',
+      'use'     => 'npm',
+      'require' => 'Anchor[nodejs::repo]',
+    }) }
+    it { should contain_package('nodejs').with({
+      'ensure'  => 'present',
+      'name'    => 'net-libs/nodejs',
+      'require' => 'Anchor[nodejs::repo]',
+    }) }
+  end
 end
 


### PR DESCRIPTION
small changes that make this work on a current gentoo/puppet setup
