### PR TITLE
support Software Collections

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,10 +29,12 @@ class nodejs(
   if $software_collections {
     $real_node_pkg = $::nodejs::params::scl_node_pkg
     $real_npm_pkg  = $::nodejs::params::scl_npm_pkg
+    $real_npm_cmd  = $::nodejs::params::scl_npm_cmd
     $real_dev_pkg  = $::nodejs::params::scl_dev_pkg
   } else {
     $real_node_pkg = $node_pkg
     $real_npm_pkg  = $npm_pkg
+    $real_npm_cmd  = 'npm'
     $real_dev_pkg  = $dev_pkg
   }
 
@@ -162,14 +164,6 @@ class nodejs(
       ensure  => link,
       target  => '/opt/rh/nodejs010/enable',
       require => Package['nodejs'],
-    }
-
-    # if we just installed nodejs from SCL, then the binaries
-    # will not yet in our path.
-    exec { 'nodejs010 enable':
-      command => '/bin/true && source /opt/rh/nodejs010/enable',
-      unless  => '/bin/echo $PATH | /bin/grep -q node',
-      path    => '/bin:/usr/bin'
     }
   }
 

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -37,7 +37,7 @@ define nodejs::npm (
 
   if $ensure == present {
     exec { "npm_install_${name}":
-      command => "npm install ${install_opt} ${install_pkg}",
+      command => "${real_npm_cmd} install ${install_opt} ${install_pkg}",
       unless  => "npm list -p -l | grep '${validate}'",
       cwd     => $npm_dir,
       path    => $::path,
@@ -48,8 +48,8 @@ define nodejs::npm (
     Exec<| title=='npm_proxy' |> -> Exec["npm_install_${name}"]
   } else {
     exec { "npm_remove_${name}":
-      command => "npm remove ${npm_pkg}",
-      onlyif  => "npm list -p -l | grep '${validate}'",
+      command => "${real_npm_cmd} remove ${npm_pkg}",
+      onlyif  => "${real_npm_cmd} list -p -l | grep '${validate}'",
       cwd     => $npm_dir,
       path    => $::path,
       require => Class['nodejs'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,6 +46,7 @@ class nodejs::params {
       $scl_enable = false
       $scl_node_pkg = 'nodejs010'
       $scl_npm_pkg = 'nodejs010-npm'
+      $scl_npm_cmd = '/usr/bin/scl enable nodejs010'
     }
 
     'Fedora': {


### PR DESCRIPTION
Red Hat (and derivatives) can access node.js via [Software Collections](https://access.redhat.com/documentation/en-US/Red_Hat_Software_Collections/1/html/1.1_Release_Notes/index.html). This pull requests adds initial Software Collections support to puppetlabs-nodejs.

There are a couple of important caveats to this PR:
- management of the Software Collections yum repository is not controlled through this module.
- this PR is hard-coded to use nodejs010.  If SCL releases a new version of nodejs, it'll require re-work on this module.
- If the optional `$scl_enable` parameter is passed to init.pp, a symlink will be created from `/opt/rh/nodejs010/enable` to `/etc/profile.d/nodejs.sh`.  Users of non-sh-compatible shells will not benefit from this. Such users are on their own.
- the custom `npm` provider included in this module has not been updated.  This means that the `npm` command will **not** work on the first invocation of this module.  Users will need to apply this module once to install the SCL packages, and then apply this module a second time in order for the `npm` command to work as expected.
