### PR TITLE
prep release for 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2016-01-07 Release 1.3.0
+
+### Fixed
+
+- Improved documentation
+- remove dependency on `treydock/gpg_key`
+- Fix `repo_url_suffix`
+- Minimum Puppet version is now set at >= 3.7.0
+- Maximum Puppet version is set to < 5.0.0
+- Expanded `global_config_entry`, made more robust
+
+### Maintenance
+
+- Integrated now with modulesync
+- Fixed loads of Rubocop complaints
+
+
 ## 2015-08-18 Release 1.2.0
 
 ### Added
@@ -8,7 +25,7 @@
 ### Fixed
 
 - Misc lint/spec fixes
-- Metadata dependency on treydock/gpg_key
+- Metadata dependency on `treydock/gpg_key`
 
 ## 2015-06-23 Release 1.1.0
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "puppet-nodejs",
-  "version": "1.2.0",
-  "author": "puppetcommunity",
+  "version": "1.3.0",
+  "author": "voxpupuli",
   "summary": "Install Node.js package and npm package provider.",
   "license": "Apache-2.0",
-  "source": "https://github.com/puppet-community/puppet-nodejs",
-  "project_page": "https://github.com/puppet-community/puppet-nodejs",
-  "issues_url": "https://github.com/puppet-community/puppet-nodejs/issues",
+  "source": "https://github.com/voxpupuli/puppet-nodejs",
+  "project_page": "https://github.com/voxpupuli/puppet-nodejs",
+  "issues_url": "https://github.com/voxpupuli/puppet-nodejs/issues",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",


### PR DESCRIPTION
This fixes #182, and goes a little beyond:) by ensuring that never happens again.

to release this, please follow [instructions](https://voxpupuli.org/docs/#releasing-a-new-version-of-a-module) to make a release