### PR TITLE
Change npm_package_name from "undef" to "false" for better comparison.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,7 +103,7 @@ class nodejs(
     validate_string($nodejs_dev_package_name)
   }
 
-  if $npm_package_name {
+  if $npm_package_name and $npm_package_name != false {
     validate_string($npm_package_name)
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,7 +46,7 @@ class nodejs::install {
   }
 
   # npm
-  if $nodejs::npm_package_name {
+  if $nodejs::npm_package_name and $nodejs::npm_package_name != false {
     package { $nodejs::npm_package_name:
       ensure => $nodejs::npm_package_ensure,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class nodejs::params {
         $nodejs_dev_package_name   = undef
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
-        $npm_package_name          = undef
+        $npm_package_name          = false
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
       }
@@ -41,7 +41,7 @@ class nodejs::params {
         $nodejs_dev_package_name   = undef
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
-        $npm_package_name          = undef
+        $npm_package_name          = false
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
       }
@@ -148,7 +148,7 @@ class nodejs::params {
       $nodejs_dev_package_name   = undef
       $nodejs_package_name       = 'node'
       $npm_package_ensure        = 'absent'
-      $npm_package_name          = undef
+      $npm_package_name          = false
       $npm_path                  = '/usr/local/bin/npm'
       $repo_class                = undef
     }
@@ -181,7 +181,7 @@ class nodejs::params {
       $nodejs_dev_package_name   = undef
       $nodejs_package_name       = 'net-libs/nodejs'
       $npm_package_ensure        = 'absent'
-      $npm_package_name          = undef
+      $npm_package_name          = false
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
     }
@@ -194,7 +194,7 @@ class nodejs::params {
           $nodejs_dev_package_name   = undef
           $nodejs_package_name       = 'net-libs/nodejs'
           $npm_package_ensure        = 'absent'
-          $npm_package_name          = undef
+          $npm_package_name          = false
           $npm_path                  = '/usr/bin/npm'
           $repo_class                = undef
         }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -322,6 +322,18 @@ describe 'nodejs', :type => :class do
           end
         end
       end
+
+      # npm_package_name
+      context 'with npm_package_name set to false' do
+        let :params do
+          {
+            :npm_package_name => 'false',
+          }
+        end
+        it 'the npm package resource should not be present' do
+          is_expected.not_to contain_package('npm')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #160 

Before:
```
# puppet apply -v  -e 'class { "nodejs": npm_package_name => undef,} package { "npm": ensure => "2.14.14", provider => "npm",}'
Info: Loading facts
Info: Loading facts
Error: Duplicate declaration: Package[npm] is already declared in file /etc/puppet/modules/nodejs/manifests/install.pp:52; cannot redeclare at line 1 on node ***
Error: Duplicate declaration: Package[npm] is already declared in file /etc/puppet/modules/nodejs/manifests/install.pp:52; cannot redeclare at line 1 on node ***
```

After:
```
# puppet apply -v  -e 'class { "nodejs": npm_package_name => false,} package { "npm": ensure => "2.14.14", provider => "npm",}'
Info: Loading facts
Info: Loading facts
Notice: Compiled catalog for *** in environment production in 0.31 seconds
Info: Applying configuration version '1452278934'
Notice: /Stage[main]/Main/Package[npm]/ensure: ensure changed '1.4.29' to '2.14.14'
Notice: Finished catalog run in 4.97 seconds
```