### PR TITLE
Making it possible to provide concrete nodejs versions to force upgrade/downgrade (#197)

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -10,7 +10,7 @@ class nodejs::repo::nodesource::apt {
 
   include ::apt
 
-  if ($ensure == 'present') {
+  if ($ensure != 'absent') {
     apt::source { 'nodesource':
       include  => {
         'src' => $enable_src,


### PR DESCRIPTION
This fixes issue #197

It is now possible to upgrade/downgrade in Debian providing (forcing) a certain version. It's also possible to use 'latest', but using latest will not downgrade your version if you want to.

upgrade
```
class { 'nodejs':
  manage_package_repo => true,
  repo_url_suffix => '5.x',
  nodejs_package_ensure => 'latest'
}
```

upgrade
```
class { 'nodejs':
  manage_package_repo => true,
  repo_url_suffix => '5.x',
  nodejs_package_ensure => '5.4.0-1nodesource1~wheezy1'
}
```

downgrade
```
class { 'nodejs':
  manage_package_repo => true,
  repo_url_suffix => '4.x',
  nodejs_package_ensure => '4.2.4-1nodesource1~wheezy1'
}
```
