### PR TITLE
Use npm view package version, fix ensure=>latest bug

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -51,15 +51,10 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
   end
 
   def latest
-    if /#{resource[:name]}@([\d\.]+)/ =~ npm('outdated', '--global', resource[:name])
-      @latest = Regexp.last_match(1)
-    else
-      @property_hash[:ensure] unless @property_hash[:ensure].is_a? Symbol
-    end
+    npm('view', resource[:name], 'version').strip
   end
 
   def update
-    resource[:ensure] = @latest
     install
   end
 


### PR DESCRIPTION
Tested with ```tar```, using npm versions 2.14.15 and 3.5.3:

* Absent->Latest
* Latest->Absent
* Absent->2.2.0
* 2.2.0->2.2.1
* 2.2.1->latest (no change)
* latest->2.2.0
* 2.2.0->absent

This method doesn't work with npm 1.4.29, as ```npm view $PACKAGE version``` returns a deprecation warning about the npm version.

Thanks to @nibalizer for the npm view version pointer