### PR TITLE
ensure apt-get update is executed before installing packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,12 +17,14 @@ class nodejs::install {
   # nodejs
   package { $nodejs::nodejs_package_name:
     ensure => $nodejs::nodejs_package_ensure,
+    tag    => 'nodesource_repo',
   }
 
   # nodejs-development
   if $nodejs::nodejs_dev_package_name {
     package { $nodejs::nodejs_dev_package_name:
       ensure => $nodejs::nodejs_dev_package_ensure,
+      tag    => 'nodesource_repo',
     }
   }
 
@@ -30,6 +32,7 @@ class nodejs::install {
   if $nodejs::nodejs_debug_package_name {
     package { $nodejs::nodejs_debug_package_name:
       ensure => $nodejs::nodejs_debug_package_ensure,
+      tag    => 'nodesource_repo',
     }
   }
 
@@ -49,6 +52,7 @@ class nodejs::install {
   if $nodejs::npm_package_name and $nodejs::npm_package_name != false {
     package { $nodejs::npm_package_name:
       ensure => $nodejs::npm_package_ensure,
+      tag    => 'nodesource_repo',
     }
   }
 }

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -28,6 +28,9 @@ class nodejs::repo::nodesource::apt {
         Package['ca-certificates'],
       ],
     }
+
+    Apt::Source['nodesource'] -> Package<| tag == 'nodesource_repo' |>
+    Class['Apt::Update'] -> Package<| tag == 'nodesource_repo' |>
   }
 
   else {


### PR DESCRIPTION
If you're using the nodesource repo, nodejs will be installed before apt-get update is run. This will result in the wrong version of nodejs.