### PR TITLE
Update validation for EL 6.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,11 +50,11 @@ class nodejs(
       }
       'RedHat': {
         # At the moment, only node v0.10 and v0.12 repos are available on
-        # nodesource for RedHat 5 and 6.
-        if $::operatingsystemrelease =~ /^[56]\.(\d+)/ {
+        # nodesource for RedHat 5.
+        if $::operatingsystemrelease =~ /^5\.(\d+)/ {
           validate_re($repo_url_suffix, '^0\.1[02]$', $suffix_error_msg)
         }
-        elsif $::operatingsystemrelease =~ /^7\.(\d+)/ {
+        elsif $::operatingsystemrelease =~ /^[67]\.(\d+)/ {
           validate_re($repo_url_suffix, '^(0\.1[02]|[45]\.x)$', $suffix_error_msg)
         }
         # Fedora

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -416,8 +416,8 @@ describe 'nodejs', type: :class do
             default_params.merge!(repo_url_suffix: '5.x',)
           end
 
-          if operatingsystemrelease =~ /^([56]\.\d+|20)$/
-            it 'NodeJS 5.x package not provided for Centos 5/6 and Fedora 20' do
+          if operatingsystemrelease =~ /^(5\.\d+|20)$/
+            it 'NodeJS 5.x package not provided for Centos 5 and Fedora 20' do
               expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '5\.x' is not set correctly for \w+ \d+(\.\d+)*\. See README\./)
             end
           else


### PR DESCRIPTION
Nodesource now supports branches 4.x and 5.x for EL6.  Updated
validation of $repo_url_suffix to allow these suffixes.