### PR TITLE
Manage /root/.npmrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,12 @@ using the EPEL repository.
 
 Path to the npm binary.
 
+#### `npmrc_auth`
+
+A string that contains the value for the key `_auth` that will be set in
+`/root/.npmrc`, as this value is not allowed to be set by
+nodejs::npm::global_config_entry. The default value is `undef`.
+
 #### `repo_class`
 
 Name of the Puppet class used for the setup and management of the Node.js

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class nodejs(
   $npm_package_ensure          = $nodejs::params::npm_package_ensure,
   $npm_package_name            = $nodejs::params::npm_package_name,
   $npm_path                    = $nodejs::params::npm_path,
+  $npmrc_auth                  = $nodejs::params::npmrc_auth,
   $repo_class                  = $nodejs::params::repo_class,
   $repo_enable_src             = $nodejs::params::repo_enable_src,
   $repo_ensure                 = $nodejs::params::repo_ensure,
@@ -105,6 +106,12 @@ class nodejs(
 
   if $npm_package_name {
     validate_string($npm_package_name)
+  }
+
+  if $npmrc_auth {
+    if is_string($npmrc_auth) == false {
+      fail('npmrc_auth must be a string')
+    }
   }
 
   validate_array($use_flags)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,8 @@
 # PRIVATE CLASS: do not call directly
 class nodejs::install {
+
+  $npmrc_auth = $::nodejs::npmrc_auth
+
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
@@ -51,5 +54,13 @@ class nodejs::install {
       ensure => $nodejs::npm_package_ensure,
     }
   }
-}
 
+  file { 'root_npmrc':
+    ensure  => 'file',
+    path    => '/root/.npmrc',
+    content => template('nodejs/npmrc.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0600',
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 class nodejs::params {
   $legacy_debian_symlinks      = false
+  $npmrc_auth                  = undef
   $nodejs_debug_package_ensure = 'absent'
   $nodejs_dev_package_ensure   = 'absent'
   $nodejs_package_ensure       = 'present'

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -46,6 +46,38 @@ describe 'nodejs', :type => :class do
         }
       end
 
+      it 'the file resource root_npmrc should be in the catalog' do
+        is_expected.to contain_file('root_npmrc').with(
+          'ensure' => 'file',
+          'path'    => '/root/.npmrc',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0600',
+        )
+      end
+
+      context 'with npmrc_auth set to a string' do
+        let :params do
+          {
+            npmrc_auth: 'dXNlcjpwYXNzd29yZA==',
+          }
+        end
+
+        it { should contain_file('root_npmrc').with_content(/^_auth="dXNlcjpwYXNzd29yZA=="$/) }
+      end
+
+      context 'with npmrc_auth set to an invalid type (non-string)' do
+        let :params do
+          {
+            npmrc_auth: %w(invalid type),
+          }
+        end
+
+        it 'should fail' do
+          expect { catalogue }.to raise_error(Puppet::Error, /npmrc_auth must be a string/)
+        end
+      end
+
       # legacy_debian_symlinks
       context 'with legacy_debian_symlinks set to true' do
         let :params do

--- a/templates/npmrc.erb
+++ b/templates/npmrc.erb
@@ -1,0 +1,6 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+
+<% if @npmrc_auth -%>
+_auth="<%= @npmrc_auth %>"
+<% end -%>


### PR DESCRIPTION
This is necessary to specify the _auth config key which cannot be set
using 'npm config set _auth'.