### PR TITLE
Do not hardcode the 'root' group name, use the 'gid' for that.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,7 +64,7 @@ class nodejs::install {
     path    => '/root/.npmrc',
     content => template('nodejs/npmrc.erb'),
     owner   => 'root',
-    group   => 'root',
+    group   => '0',
     mode    => '0600',
   }
 }

--- a/manifests/repo/nodesource/yum.pp
+++ b/manifests/repo/nodesource/yum.pp
@@ -48,7 +48,7 @@ class nodejs::repo::nodesource::yum {
 
     file { '/etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL':
       ensure => file,
-      group  => 'root',
+      group  => '0',
       mode   => '0644',
       owner  => 'root',
       source => "puppet:///modules/${module_name}/repo/nodesource/NODESOURCE-GPG-SIGNING-KEY-EL",

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -51,7 +51,7 @@ describe 'nodejs', type: :class do
           'ensure' => 'file',
           'path'    => '/root/.npmrc',
           'owner'   => 'root',
-          'group'   => 'root',
+          'group'   => '0',
           'mode'    => '0600',
         )
       end


### PR DESCRIPTION
Non-Linux systems, i.e. *BSD might not have a group 'root', but
have group wheel.
What is in common everywhere is the 'gid' of these groups is '0'.

Setting the group => '0' instead of group => 'root' is a common
pattern seen in many other modules.

This fixes the setting of the group for the npmrc file.
For consistency, I also changed the group in manifests/repo/nodesource/yum.pp
even it doesn't affect me.

Ran into the problem on OpenBSD.