### PR TITLE
WIP: Validate soft dependencies exist in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,13 @@ class nodejs::params {
       if $::operatingsystemrelease =~ /^6\.(\d+)/ {
         fail("The ${module_name} module is not supported on Debian Squeeze.")
       }
+      # validate apt module exists
+      $apt_data = load_module_metadata('apt', true)
+      if $apt_data = {} {
+        fail("The apt module is required for ${module_name}, install it with 'puppet module install puppetlabs-apt'")
+      } else {
+        # optionally do any version checking, name validation here
+      }
       if $::operatingsystemrelease =~ /^7\.(\d+)/ {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'


### PR DESCRIPTION
As a potential way of helping the user with soft dependencies, we can
attempt to load the module metadata. If we don't get any metadata back,
that probably means the module is not installed. We can then warn the
user that they need to install it.

We can also inspect returned metadata for version and author
compatibility, though ideally we would be very very lax.