### PR TITLE
Ignore npm cache lines when calling 'npm view' for latest version

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:package).provide :npm, parent: Puppet::Provider::Package do
   end
 
   def latest
-    npm('view', resource[:name], 'version').strip
+    npm('view', resource[:name], 'version').lines.reject { |l| l.start_with?('npm') }.join("\n").strip
   end
 
   def update

--- a/spec/unit/puppet/provider/package/npm_spec.rb
+++ b/spec/unit/puppet/provider/package/npm_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Type.type(:package).provider(:npm) do
   end
 
   describe 'when npm packages are installed globally' do
-    before :each do
+    before do
       provider.class.instance_variable_set(:@npmlist, nil)
     end
 
@@ -65,6 +65,13 @@ describe Puppet::Type.type(:package).provider(:npm) do
       Process::Status.any_instance.expects(:success?).returns(true) # rubocop:disable RSpec/AnyInstance
       Puppet.expects(:debug).with(regexp_matches(%r{npm list.*failure!}))
       expect(provider.class.instances).to eq([])
+    end
+  end
+
+  describe '#latest' do
+    it 'filters npm registry logging' do
+      provider.expects(:npm).with('view', 'express', 'version').returns("npm http GET https://registry.npmjs.org/express\nnpm http 200 https://registry.npmjs.org/express\n2.0.0")
+      expect(provider.latest).to eq('2.0.0')
     end
   end
 end


### PR DESCRIPTION
When the npm cache has expired or is empty, npm (version 1.3.6 at least)
outputs requests it's making to stderr which are interpreted as a
version number from the `npm view` command.

If using ensure=latest, this causes the package to be reinstalled every
time the cache expires:

    Debug: Executing: '/bin/npm view phantomjs version'
    Debug: /Package[phantomjs]/ensure: phantomjs "2.1.7" is installed, latest is "npm http GET https://registry.npmjs.org/phantomjs\nnpm http 200 https://registry.npmjs.org/phantomjs\n2.1.7"
    Debug: Executing: '/bin/npm install --global phantomjs'
    Debug: /Package[phantomjs]/ensure: phantomjs "2.1.7" is installed, latest is "npm http GET https://registry.npmjs.org/phantomjs\nnpm http 200 https://registry.npmjs.org/phantomjs\n2.1.7"
    Notice: /Package[phantomjs]/ensure: ensure changed '2.1.7' to 'npm http GET https://registry.npmjs.org/phantomjs
    npm http 200 https://registry.npmjs.org/phantomjs
    2.1.7'

The npm logging lines are now filtered out similarly to the `npm list`
command.