### PR TITLE
Fix for NPM and Node.JS installation on Ubuntu 16.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ Gemfile.lock
 Gemfile.local
 vendor/
 .vendor/
-spec/fixtures/
+spec/fixtures/manifests/
+spec/fixtures/modules/
 .vagrant/
 .bundle/
 coverage/

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '0.11.1'
+modulesync_config_version: '0.12.9'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,481 +4,482 @@ AllCops:
   Include:
     - ./**/*.rb
   Exclude:
+    - files/**/*
     - vendor/**/*
     - .vendor/**/*
     - pkg/**/*
     - spec/fixtures/**/*
 Lint/ConditionPosition:
-  Enabled: true
+  Enabled: True
 
 Lint/ElseLayout:
-  Enabled: true
+  Enabled: True
 
 Lint/UnreachableCode:
-  Enabled: true
+  Enabled: True
 
 Lint/UselessComparison:
-  Enabled: true
+  Enabled: True
 
 Lint/EnsureReturn:
-  Enabled: true
+  Enabled: True
 
 Lint/HandleExceptions:
-  Enabled: true
+  Enabled: True
 
 Lint/LiteralInCondition:
-  Enabled: true
+  Enabled: True
 
 Lint/ShadowingOuterLocalVariable:
-  Enabled: true
+  Enabled: True
 
 Lint/LiteralInInterpolation:
-  Enabled: true
+  Enabled: True
 
 Style/HashSyntax:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantReturn:
-  Enabled: true
+  Enabled: True
 
 Lint/AmbiguousOperator:
-  Enabled: true
+  Enabled: True
 
 Lint/AssignmentInCondition:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeComment:
-  Enabled: true
+  Enabled: True
 
 Style/AndOr:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantSelf:
-  Enabled: true
+  Enabled: True
 
 # Method length is not necessarily an indicator of code quality
 Metrics/MethodLength:
-  Enabled: false
+  Enabled: False
 
 # Module length is not necessarily an indicator of code quality
 Metrics/ModuleLength:
-  Enabled: false
+  Enabled: False
 
 Style/WhileUntilModifier:
-  Enabled: true
+  Enabled: True
 
 Lint/AmbiguousRegexpLiteral:
-  Enabled: true
+  Enabled: True
 
 Lint/Eval:
-  Enabled: true
+  Enabled: True
 
 Lint/BlockAlignment:
-  Enabled: true
+  Enabled: True
 
 Lint/DefEndAlignment:
-  Enabled: true
+  Enabled: True
 
 Lint/EndAlignment:
-  Enabled: true
+  Enabled: True
 
 Lint/DeprecatedClassMethods:
-  Enabled: true
+  Enabled: True
 
 Lint/Loop:
-  Enabled: true
+  Enabled: True
 
 Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
+  Enabled: True
 
 Lint/RescueException:
-  Enabled: true
+  Enabled: True
 
 Lint/StringConversionInInterpolation:
-  Enabled: true
+  Enabled: True
 
 Lint/UnusedBlockArgument:
-  Enabled: true
+  Enabled: True
 
 Lint/UnusedMethodArgument:
-  Enabled: true
+  Enabled: True
 
 Lint/UselessAccessModifier:
-  Enabled: true
+  Enabled: True
 
 Lint/UselessAssignment:
-  Enabled: true
+  Enabled: True
 
 Lint/Void:
-  Enabled: true
+  Enabled: True
 
 Style/AccessModifierIndentation:
-  Enabled: true
+  Enabled: True
 
 Style/AccessorMethodName:
-  Enabled: true
+  Enabled: True
 
 Style/Alias:
-  Enabled: true
+  Enabled: True
 
 Style/AlignArray:
-  Enabled: true
+  Enabled: True
 
 Style/AlignHash:
-  Enabled: true
+  Enabled: True
 
 Style/AlignParameters:
-  Enabled: true
+  Enabled: True
 
 Metrics/BlockNesting:
-  Enabled: true
+  Enabled: True
 
 Style/AsciiComments:
-  Enabled: true
+  Enabled: True
 
 Style/Attr:
-  Enabled: true
+  Enabled: True
 
 Style/BracesAroundHashParameters:
-  Enabled: true
+  Enabled: True
 
 Style/CaseEquality:
-  Enabled: true
+  Enabled: True
 
 Style/CaseIndentation:
-  Enabled: true
+  Enabled: True
 
 Style/CharacterLiteral:
-  Enabled: true
+  Enabled: True
 
 Style/ClassAndModuleCamelCase:
-  Enabled: true
+  Enabled: True
 
 Style/ClassAndModuleChildren:
-  Enabled: false
+  Enabled: False
 
 Style/ClassCheck:
-  Enabled: true
+  Enabled: True
 
 # Class length is not necessarily an indicator of code quality
 Metrics/ClassLength:
-  Enabled: false
+  Enabled: False
 
 Style/ClassMethods:
-  Enabled: true
+  Enabled: True
 
 Style/ClassVars:
-  Enabled: true
+  Enabled: True
 
 Style/WhenThen:
-  Enabled: true
+  Enabled: True
 
 Style/WordArray:
-  Enabled: true
+  Enabled: True
 
 Style/UnneededPercentQ:
-  Enabled: true
+  Enabled: True
 
 Style/Tab:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeSemicolon:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingBlankLines:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideBlockBraces:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideBrackets:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideHashLiteralBraces:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceInsideParens:
-  Enabled: true
+  Enabled: True
 
 Style/LeadingCommentSpace:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeFirstArg:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterColon:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterComma:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterMethodName:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterNot:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAfterSemicolon:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceAroundOperators:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeBlockBraces:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeComma:
-  Enabled: true
+  Enabled: True
 
 Style/CollectionMethods:
-  Enabled: true
+  Enabled: True
 
 Style/CommentIndentation:
-  Enabled: true
+  Enabled: True
 
 Style/ColonMethodCall:
-  Enabled: true
+  Enabled: True
 
 Style/CommentAnnotation:
-  Enabled: true
+  Enabled: True
 
 # 'Complexity' is very relative
 Metrics/CyclomaticComplexity:
-  Enabled: false
+  Enabled: False
 
 Style/ConstantName:
-  Enabled: true
+  Enabled: True
 
 Style/Documentation:
-  Enabled: false
+  Enabled: False
 
 Style/DefWithParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/PreferredHashMethods:
-  Enabled: true
+  Enabled: True
 
 Style/DotPosition:
   EnforcedStyle: trailing
 
 Style/DoubleNegation:
-  Enabled: true
+  Enabled: True
 
 Style/EachWithObject:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLineBetweenDefs:
-  Enabled: true
+  Enabled: True
 
 Style/IndentArray:
-  Enabled: true
+  Enabled: True
 
 Style/IndentHash:
-  Enabled: true
+  Enabled: True
 
 Style/IndentationConsistency:
-  Enabled: true
+  Enabled: True
 
 Style/IndentationWidth:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLines:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLinesAroundAccessModifier:
-  Enabled: true
+  Enabled: True
 
 Style/EmptyLiteral:
-  Enabled: true
+  Enabled: True
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
-  Enabled: false
+  Enabled: False
 
 Style/MethodCallParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/MethodDefParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/LineEndConcatenation:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingWhitespace:
-  Enabled: true
+  Enabled: True
 
 Style/StringLiterals:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingCommaInArguments:
-  Enabled: true
+  Enabled: True
 
 Style/TrailingCommaInLiteral:
-  Enabled: true
+  Enabled: True
 
 Style/GlobalVars:
-  Enabled: true
+  Enabled: True
 
 Style/GuardClause:
-  Enabled: true
+  Enabled: True
 
 Style/IfUnlessModifier:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineIfThen:
-  Enabled: true
+  Enabled: True
 
 Style/NegatedIf:
-  Enabled: true
+  Enabled: True
 
 Style/NegatedWhile:
-  Enabled: true
+  Enabled: True
 
 Style/Next:
-  Enabled: true
+  Enabled: True
 
 Style/SingleLineBlockParams:
-  Enabled: true
+  Enabled: True
 
 Style/SingleLineMethods:
-  Enabled: true
+  Enabled: True
 
 Style/SpecialGlobalVars:
-  Enabled: true
+  Enabled: True
 
 Style/TrivialAccessors:
-  Enabled: true
+  Enabled: True
 
 Style/UnlessElse:
-  Enabled: true
+  Enabled: True
 
 Style/VariableInterpolation:
-  Enabled: true
+  Enabled: True
 
 Style/VariableName:
-  Enabled: true
+  Enabled: True
 
 Style/WhileUntilDo:
-  Enabled: true
+  Enabled: True
 
 Style/EvenOdd:
-  Enabled: true
+  Enabled: True
 
 Style/FileName:
-  Enabled: true
+  Enabled: True
 
 Style/For:
-  Enabled: true
+  Enabled: True
 
 Style/Lambda:
-  Enabled: true
+  Enabled: True
 
 Style/MethodName:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineTernaryOperator:
-  Enabled: true
+  Enabled: True
 
 Style/NestedTernaryOperator:
-  Enabled: true
+  Enabled: True
 
 Style/NilComparison:
-  Enabled: true
+  Enabled: True
 
 Style/FormatString:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineBlockChain:
-  Enabled: true
+  Enabled: True
 
 Style/Semicolon:
-  Enabled: true
+  Enabled: True
 
 Style/SignalException:
-  Enabled: true
+  Enabled: True
 
 Style/NonNilCheck:
-  Enabled: true
+  Enabled: True
 
 Style/Not:
-  Enabled: true
+  Enabled: True
 
 Style/NumericLiterals:
-  Enabled: true
+  Enabled: True
 
 Style/OneLineConditional:
-  Enabled: true
+  Enabled: True
 
 Style/OpMethod:
-  Enabled: true
+  Enabled: True
 
 Style/ParenthesesAroundCondition:
-  Enabled: true
+  Enabled: True
 
 Style/PercentLiteralDelimiters:
-  Enabled: true
+  Enabled: True
 
 Style/PerlBackrefs:
-  Enabled: true
+  Enabled: True
 
 Style/PredicateName:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantException:
-  Enabled: true
+  Enabled: True
 
 Style/SelfAssignment:
-  Enabled: true
+  Enabled: True
 
 Style/Proc:
-  Enabled: true
+  Enabled: True
 
 Style/RaiseArgs:
-  Enabled: true
+  Enabled: True
 
 Style/RedundantBegin:
-  Enabled: true
+  Enabled: True
 
 Style/RescueModifier:
-  Enabled: true
+  Enabled: True
 
 # based on https://github.com/voxpupuli/modulesync_config/issues/168
 Style/RegexpLiteral:
   EnforcedStyle: percent_r
-  Enabled: true
+  Enabled: True
 
 Lint/UnderscorePrefixedVariableName:
-  Enabled: true
+  Enabled: True
 
 Metrics/ParameterLists:
-  Enabled: false
+  Enabled: False
 
 Lint/RequireParentheses:
-  Enabled: true
+  Enabled: True
 
 Style/SpaceBeforeFirstArg:
-  Enabled: true
+  Enabled: True
 
 Style/ModuleFunction:
-  Enabled: true
+  Enabled: True
 
 Lint/Debugger:
-  Enabled: true
+  Enabled: True
 
 Style/IfWithSemicolon:
-  Enabled: true
+  Enabled: True
 
 Style/Encoding:
-  Enabled: true
+  Enabled: True
 
 Style/BlockDelimiters:
-  Enabled: true
+  Enabled: True
 
 Style/MultilineBlockLayout:
-  Enabled: true
+  Enabled: True
 
 # 'Complexity' is very relative
 Metrics/AbcSize:
@@ -489,10 +490,10 @@ Metrics/PerceivedComplexity:
   Enabled: False
 
 Lint/UselessAssignment:
-  Enabled: true
+  Enabled: True
 
 Style/ClosingParenthesisIndentation:
-  Enabled: false
+  Enabled: True
 
 # RSpec
 
@@ -502,4 +503,7 @@ RSpec/DescribeClass:
 
 # Example length is not necessarily an indicator of code quality
 RSpec/ExampleLength:
+  Enabled: False
+
+RSpec/NamedSubject:
   Enabled: False

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,24 +19,30 @@ matrix:
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes" CHECK=test
-  - rvm: 2.1
+  - rvm: 2.1.9
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
-  - rvm: 2.2
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+  - rvm: 2.2.5
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=build
+    env: PUPPET_VERSION="~> 4.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=rubocop
+    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
   - rvm: 2.3.1
-    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes" CHECK=test
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
+  - rvm: 2.4.0-preview1
+    env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+  allow_failures:
+    - rvm: 2.4.0-preview1
 notifications:
   email: false
 deploy:
   provider: puppetforge
+  deploy:
+    branch: ha-bug-puppet-forge
   user: puppet
   password:
     secure: "SCQpiBB9qpZAjBRk+b9D3cSCQfYpDgHPOdOc7djfGeB5yn1UbGg7uW1zshrshb4QMLfUgvsL4LsT0CYj7ilBerghgeySF5JWuZdk05W/7Iudls4btbxdVjqtALR7p02mnk40qHTR1Tdb/j0gXW9uigU6nQU9iCP+Poa1KF6PXpk="
@@ -44,5 +50,5 @@ deploy:
     tags: true
     # all_branches is required to use tags
     all_branches: true
-    # Only publish if our main Ruby target builds
-    rvm: 2.3.1
+    # Only publish the build marked with "DEPLOY_TO_FORGE"
+    condition: "$DEPLOY_TO_FORGE = yes"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'puppetlabs_spec_helper',                                     :require => false
+  gem 'puppetlabs_spec_helper', '~> 1.2.2',                         :require => false
   gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
@@ -25,8 +25,8 @@ group :test do
   gem 'metadata-json-lint',                                         :require => false
   gem 'puppet-blacksmith',                                          :require => false
   gem 'voxpupuli-release',                                          :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem.git'
-  gem 'puppet-strings',                                             :require => false, :git => 'https://github.com/puppetlabs/puppetlabs-strings.git'
-  gem 'rubocop-rspec', '~> 1.5',                                    :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'puppet-strings', '0.4.0',                                    :require => false
+  gem 'rubocop-rspec', '~> 1.6',                                    :require => false if RUBY_VERSION >= '2.3.0'
   gem 'json_pure', '<= 2.0.1',                                      :require => false if RUBY_VERSION < '2.0.0'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -34,11 +34,9 @@ RSpec::Core::RakeTask.new(:acceptance) do |t|
   t.pattern = 'spec/acceptance'
 end
 
-desc 'Run tests metadata_lint, lint, syntax, spec'
+desc 'Run tests metadata_lint, release_checks'
 task test: [
   :metadata_lint,
-  :lint,
-  :syntax,
-  :spec,
+  :release_checks,
 ]
 # vim: syntax=ruby

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,6 @@
 class nodejs::params {
   $npmrc_auth                  = undef
   $nodejs_debug_package_ensure = 'absent'
-  $nodejs_dev_package_ensure   = 'absent'
   $nodejs_package_ensure       = 'present'
   $repo_enable_src             = false
   $repo_ensure                 = 'present'
@@ -30,6 +29,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = undef
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = false
@@ -41,6 +41,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = undef
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = false
@@ -52,6 +53,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
@@ -63,6 +65,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
@@ -74,6 +77,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
+        $nodejs_dev_package_ensure = 'present'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'present'
         $npm_package_name          = 'npm'
@@ -86,6 +90,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
@@ -100,6 +105,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-debuginfo'
         $nodejs_dev_package_name   = 'nodejs-devel'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
@@ -110,6 +116,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-debuginfo'
         $nodejs_dev_package_name   = 'nodejs-devel'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
@@ -120,6 +127,7 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-debuginfo'
         $nodejs_dev_package_name   = 'nodejs-devel'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
@@ -135,6 +143,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = 'nodejs-debuginfo'
       $nodejs_dev_package_name   = 'nodejs-devel'
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'nodejs'
       $npm_package_ensure        = 'present'
       $npm_package_name          = 'npm'
@@ -146,6 +155,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'nodejs'
       $npm_package_ensure        = 'present'
       $npm_package_name          = 'npm'
@@ -157,6 +167,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = 'www/node-devel'
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'www/node'
       $npm_package_ensure        = 'present'
       $npm_package_name          = 'www/npm'
@@ -168,6 +179,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'node'
       $npm_package_ensure        = 'absent'
       $npm_package_name          = false
@@ -179,6 +191,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = 'nodejs-devel'
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'nodejs'
       $npm_package_ensure        = 'present'
       $npm_package_name          = 'npm'
@@ -191,6 +204,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'nodejs'
       $npm_package_ensure        = 'absent'
       $npm_package_name          = 'npm'
@@ -204,6 +218,7 @@ class nodejs::params {
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
+      $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'net-libs/nodejs'
       $npm_package_ensure        = 'absent'
       $npm_package_name          = false
@@ -218,6 +233,7 @@ class nodejs::params {
           $manage_package_repo       = false
           $nodejs_debug_package_name = undef
           $nodejs_dev_package_name   = undef
+          $nodejs_dev_package_ensure = 'absent'
           $nodejs_package_name       = 'net-libs/nodejs'
           $npm_package_ensure        = 'absent'
           $npm_package_name          = false
@@ -231,6 +247,7 @@ class nodejs::params {
           $manage_package_repo       = true
           $nodejs_debug_package_name = 'nodejs-debuginfo'
           $nodejs_dev_package_name   = 'nodejs-devel'
+          $nodejs_dev_package_ensure = 'absent'
           $nodejs_package_name       = 'nodejs'
           $npm_package_ensure        = 'absent'
           $npm_package_name          = 'npm'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,4 @@
 class nodejs::params {
-  $legacy_debian_symlinks      = false
   $npmrc_auth                  = undef
   $nodejs_debug_package_ensure = 'absent'
   $nodejs_dev_package_ensure   = 'absent'
@@ -27,6 +26,7 @@ class nodejs::params {
         fail("The ${module_name} module is not supported on Debian Squeeze.")
       }
       if $::operatingsystemrelease =~ /^7\.(\d+)/ {
+        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = undef
@@ -37,6 +37,7 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
       elsif $::operatingsystemrelease =~ /^10.04$/ {
+        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = undef
@@ -47,6 +48,7 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
       elsif $::operatingsystemrelease =~ /^12.04$/ {
+        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
@@ -57,6 +59,7 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
       elsif $::operatingsystemrelease =~ /^14.04$/ {
+        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
@@ -67,6 +70,7 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
       elsif $::operatingsystemrelease =~ /^16.04$/ {
+        $legacy_debian_symlinks    = true
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
@@ -78,6 +82,7 @@ class nodejs::params {
       }
       else {
         warning("The ${module_name} module might not work on ${::operatingsystem} ${::operatingsystemrelease}. Sensible defaults will be attempted.")
+        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
@@ -89,6 +94,8 @@ class nodejs::params {
       }
     }
     'RedHat': {
+      $legacy_debian_symlinks      = false
+
       if $::operatingsystemrelease =~ /^[5-7]\.(\d+)/ {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-debuginfo'
@@ -124,6 +131,7 @@ class nodejs::params {
       }
     }
     'Suse': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = 'nodejs-debuginfo'
       $nodejs_dev_package_name   = 'nodejs-devel'
@@ -134,6 +142,7 @@ class nodejs::params {
       $repo_class                = undef
     }
     'Archlinux': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -144,6 +153,7 @@ class nodejs::params {
       $repo_class                = undef
     }
     'FreeBSD': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = 'www/node-devel'
@@ -154,6 +164,7 @@ class nodejs::params {
       $repo_class                = undef
     }
     'OpenBSD': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -164,6 +175,7 @@ class nodejs::params {
       $repo_class                = undef
     }
     'Darwin': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = 'nodejs-devel'
@@ -175,6 +187,7 @@ class nodejs::params {
       Package { provider => 'macports' }
     }
     'Windows': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -187,6 +200,7 @@ class nodejs::params {
     }
     # Gentoo was added as its own $::osfamily in Facter 1.7.0
     'Gentoo': {
+      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -200,6 +214,7 @@ class nodejs::params {
     # Before Facter 1.7.0 Gentoo did not have its own $::osfamily
       case $::operatingsystem {
         'Gentoo': {
+          $legacy_debian_symlinks    = false
           $manage_package_repo       = false
           $nodejs_debug_package_name = undef
           $nodejs_dev_package_name   = undef
@@ -212,6 +227,7 @@ class nodejs::params {
         'Amazon': {
           # this is here only for historical reasons:
           # old facter and Amazon Linux versions will run into this code path
+          $legacy_debian_symlinks    = false
           $manage_package_repo       = true
           $nodejs_debug_package_name = 'nodejs-debuginfo'
           $nodejs_dev_package_name   = 'nodejs-devel'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,8 @@ RSpec.configure do |c|
     puppetversion: Puppet.version,
     facterversion: Facter.version
   }
-  default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_facts.yml')
-  default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_module_facts.yml')
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
   c.default_facts = default_facts
 end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

On Ubuntu 16.04 the system will no longer update the /etc/alternatives/node by default.  This results in applications like Yeoman not being able to execute with a `sh: 1: node: not found` error.  Setting the value to `true` solves the problem.  This is a revised pull request (in place of [https://github.com/voxpupuli/puppet-nodejs/pull/247}(https://github.com/voxpupuli/puppet-nodejs/pull/247) with new modulesync attempt, explicit definition of the legacy debian symlink and nodejs dev package variables.

This problem is also described here:  [http://stackoverflow.com/questions/21168141/cannot-install-packages-using-node-package-manager-in-ubuntu](http://stackoverflow.com/questions/21168141/cannot-install-packages-using-node-package-manager-in-ubuntu).  I cannot confirm its behavior on older Ubuntu distributions but reliably on 16.04 npm is actively removed and node's symlink not created, even when using the master from the repo.