### PR TITLE
Actually remove gpg_key dependency.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -81,10 +81,6 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.1.0 <5.0.0"
-    },
-    {
-      "name": "treydock/gpg_key",
-      "version_requirement": ">=0.0.3 <1.0.0"
     }
   ]
 }


### PR DESCRIPTION
The changelog for release 1.3.0 states that the gpg_key dependency is removed. This
should be reflected in metadata.json.