### PR TITLE
Use http instead of https (sic) for apt source

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -17,9 +17,9 @@ class nodejs::repo::nodesource::apt {
       },
       key      => {
         'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
-        'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
+        'source' => 'http://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       },
-      location => "https://deb.nodesource.com/node_${url_suffix}",
+      location => "http://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
       release  => $::lsbdistcodename,
       repos    => 'main',

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -19,6 +19,7 @@ class nodejs::repo::nodesource::apt {
         'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
         'source' => 'http://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       },
+      /* using HTTP due to https://github.com/nodesource/distributions/issues/388 */
       location => "http://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
       release  => $::lsbdistcodename,

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -17,7 +17,7 @@ class nodejs::repo::nodesource::apt {
       },
       key      => {
         'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
-        'source' => 'http://deb.nodesource.com/gpgkey/nodesource.gpg.key',
+        'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       },
       /* using HTTP due to https://github.com/nodesource/distributions/issues/388 */
       location => "http://deb.nodesource.com/node_${url_suffix}",

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -19,7 +19,7 @@ class nodejs::repo::nodesource::apt {
         'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
         'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       },
-      /* using HTTP due to https://github.com/nodesource/distributions/issues/388 */
+      # using HTTP due to https://github.com/nodesource/distributions/issues/388 
       location => "http://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
       release  => $::lsbdistcodename,

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -157,8 +157,8 @@ describe 'nodejs', type: :class do
               expect { catalogue }.to raise_error(Puppet::Error, %r{Var \$repo_url_suffix with value '0\.12' is not set correctly for Ubuntu 10\.04\. See README\.})
             end
           else
-            it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_0.12' do
-              is_expected.to contain_apt__source('nodesource').with('location' => 'https://deb.nodesource.com/node_0.12')
+            it 'the repo apt::source resource should contain location = http://deb.nodesource.com/node_0.12' do
+              is_expected.to contain_apt__source('nodesource').with('location' => 'http://deb.nodesource.com/node_0.12')
             end
           end
         end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

This is a workaround for nodesource/distributions#388. `deb.nodesource.com` moved to CloudFront and some Linux distros (like Ubuntu 14.04) are unable to fetch packages from there because SSL with SNI is required.

A work-around is to fall back to HTTP for the time being. Note that this supposed not to impair package integrity checking, although I cannot tell whether this makes sense if the key is retrieved over HTTP as well.