### PR TITLE
provider: add support for install_options

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:package).provide :npm, parent: Puppet::Provider::Package do
 
   confine feature: :npm
 
-  has_feature :versionable
+  has_feature :versionable, :install_options
 
   if Puppet::Util::Package.versioncmp(Puppet.version, '3.0') >= 0
     has_command(:npm, 'npm') do
@@ -67,14 +67,21 @@ Puppet::Type.type(:package).provide :npm, parent: Puppet::Provider::Package do
                 "#{resource[:name]}@#{resource[:ensure]}"
               end
 
+    options = %w(--global)
+    options += install_options if @resource[:install_options]
+
     if resource[:source]
-      npm('install', '--global', resource[:source])
+      npm('install', *options, resource[:source])
     else
-      npm('install', '--global', package)
+      npm('install', *options, package)
     end
   end
 
   def uninstall
     npm('uninstall', '--global', resource[:name])
+  end
+
+  def install_options
+    join_options(@resource[:install_options])
   end
 end

--- a/spec/unit/puppet/provider/package/npm_spec.rb
+++ b/spec/unit/puppet/provider/package/npm_spec.rb
@@ -37,6 +37,22 @@ describe Puppet::Type.type(:package).provider(:npm) do
         provider.install
       end
     end
+
+    describe 'and install_options is a string' do
+      it 'passes the install_options to npm' do
+        resource[:install_options] = ['--verbose']
+        provider.expects(:npm).with('install', '--global', '--verbose', 'express')
+        provider.install
+      end
+    end
+
+    describe 'and install_options is a hash' do
+      it 'passes the install_options to npm' do
+        resource[:install_options] = [{ '--loglevel' => 'error' }]
+        provider.expects(:npm).with('install', '--global', '--loglevel=error', 'express')
+        provider.install
+      end
+    end
   end
 
   describe 'when npm packages are installed globally' do


### PR DESCRIPTION
Use case:
pass "--loglevel=error" to npm, in order to hide warnings for deprecated dependencies during CI runs

(eg. gulp 3, https://github.com/gulpjs/gulp/issues/1806)