### PR TITLE
[FIX] Nodesource 6.x nodejs package replaces nodejs-dev & npm packages

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,9 +77,9 @@ class nodejs::params {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
-        $nodejs_dev_package_ensure = 'present'
+        $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
-        $npm_package_ensure        = 'present'
+        $npm_package_ensure        = 'absent'
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

This should fix #264

On Ubuntu 16.04 Xenial: https://deb.nodesource.com/node_6.x/dists/xenial/main/binary-amd64/Packages

nodejs package replaces nodejs-dev and npm packages, no need to install those by default.