### PR TITLE
Bump min version_requirement for Puppet + dep

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -69,18 +69,14 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.7.0 <5.0.0"
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.1.0 <5.0.0"
+      "version_requirement": ">=4.6.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump stdlib to the minimum version that should work under Puppet 4,
based on the metadata

Also remove deprecated pe version_requirement field