### PR TITLE
Fix dependency cycle error

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -23,10 +23,6 @@ class nodejs::repo::nodesource::apt {
       pin      => $pin,
       release  => $::lsbdistcodename,
       repos    => 'main',
-      require  => [
-        Package['apt-transport-https'],
-        Package['ca-certificates'],
-      ],
     }
 
     Apt::Source['nodesource'] -> Package<| tag == 'nodesource_repo' |>


### PR DESCRIPTION
This fixes the dependency cycle error reported in issue #281 .
Since `ensure_packages` is used, the `require` statement is obsolete.

Tested on Ubuntu 16.04.2 LTS.