### PR TITLE
Add the ability to manage dependent packages else where.

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,12 @@ that were available on 2017-01-08:
 The USE flags to use for the Node.js package on Gentoo systems. Defaults to
 ['npm', 'snapshot'].
 
+#### `manage_dep_packages`
+
+Specify if hte puppet-nodejs module should install dependent packages
+required by nodejs. If you manage these packages elsehwere, set to
+false.  Defaults to `true`.
+
 ## Limitations
 
 This module has received limited testing on:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class nodejs(
   $repo_proxy_username         = $nodejs::params::repo_proxy_username,
   $repo_url_suffix             = $nodejs::params::repo_url_suffix,
   $use_flags                   = $nodejs::params::use_flags,
+  $manage_dep_packages         = $nodejs::params::manage_dep_packages,
 ) inherits nodejs::params {
 
   validate_bool($legacy_debian_symlinks)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class nodejs::params {
   $repo_proxy_username         = 'absent'
   $repo_url_suffix             = '0.10'
   $use_flags                   = ['npm', 'snapshot']
+  $manage_dep_packages         = true
 
   # The full path to cmd.exe is required on Windows. The system32 fact is only
   # available from Facter 2.3

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -1,13 +1,14 @@
 # PRIVATE CLASS: Do not use directly
 class nodejs::repo::nodesource {
-  $enable_src     = $nodejs::repo_enable_src
-  $ensure         = $nodejs::repo_ensure
-  $pin            = $nodejs::repo_pin
-  $priority       = $nodejs::repo_priority
-  $proxy          = $nodejs::repo_proxy
-  $proxy_password = $nodejs::repo_proxy_password
-  $proxy_username = $nodejs::repo_proxy_username
-  $url_suffix     = $nodejs::repo_url_suffix
+  $enable_src          = $nodejs::repo_enable_src
+  $ensure              = $nodejs::repo_ensure
+  $pin                 = $nodejs::repo_pin
+  $priority            = $nodejs::repo_priority
+  $proxy               = $nodejs::repo_proxy
+  $proxy_password      = $nodejs::repo_proxy_password
+  $proxy_username      = $nodejs::repo_proxy_username
+  $url_suffix          = $nodejs::repo_url_suffix
+  $manage_dep_packages = $nodejs::manage_dep_packages
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -1,12 +1,21 @@
 # PRIVATE CLASS: Do not use directly.
 class nodejs::repo::nodesource::apt {
 
-  $enable_src = $nodejs::repo::nodesource::enable_src
-  $ensure     = $nodejs::repo::nodesource::ensure
-  $pin        = $nodejs::repo::nodesource::pin
-  $url_suffix = $nodejs::repo::nodesource::url_suffix
+  $enable_src          = $nodejs::repo::nodesource::enable_src
+  $ensure              = $nodejs::repo::nodesource::ensure
+  $pin                 = $nodejs::repo::nodesource::pin
+  $url_suffix          = $nodejs::repo::nodesource::url_suffix
+  $manage_dep_packages = $nodejs::repo::manage_dep_packages
 
-  ensure_packages(['apt-transport-https', 'ca-certificates'])
+  if $manage_dep_packages {
+    ensure_packages(['apt-transport-https', 'ca-certificates'])
+    $require = [
+      Package['apt-transport-https'],
+      Package['ca-certificates'],
+    ]
+  } else {
+    $require = undef
+  }
 
   include ::apt
 
@@ -23,10 +32,7 @@ class nodejs::repo::nodesource::apt {
       pin      => $pin,
       release  => $::lsbdistcodename,
       repos    => 'main',
-      require  => [
-        Package['apt-transport-https'],
-        Package['ca-certificates'],
-      ],
+      require  => $require,
     }
 
     Apt::Source['nodesource'] -> Package<| tag == 'nodesource_repo' |>


### PR DESCRIPTION
We already manage one of the packages (`ca-certificates`) elsewhere.  This adds the ability to manage dependent packages outside of the nodejs module to avoid duplicate package definitions.  