### PR TITLE
Add support for Debian Stretch

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -11,6 +11,10 @@ class nodejs::repo::nodesource::apt {
   include ::apt
 
   if ($ensure != 'absent') {
+    $releasename = $::lsbdistcodename ? {
+      'stretch' => 'jessie',
+      default   => $::lsbdistcodename,
+    }
     apt::source { 'nodesource':
       include  => {
         'src' => $enable_src,
@@ -21,7 +25,7 @@ class nodejs::repo::nodesource::apt {
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
-      release  => $::lsbdistcodename,
+      release  => $releasename,
       repos    => 'main',
       require  => [
         Package['apt-transport-https'],


### PR DESCRIPTION
Per [Nodesource](https://github.com/nodesource/distributions/blob/master/README.md), they support stretch via an alias to jessie.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
