### PR TITLE
Update acceptance tests, add EPEL test case for RedHat acceptance tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,7 @@
 ---
 .travis.yml:
   secure: "SCQpiBB9qpZAjBRk+b9D3cSCQfYpDgHPOdOc7djfGeB5yn1UbGg7uW1zshrshb4QMLfUgvsL4LsT0CYj7ilBerghgeySF5JWuZdk05W/7Iudls4btbxdVjqtALR7p02mnk40qHTR1Tdb/j0gXW9uigU6nQU9iCP+Poa1KF6PXpk="
+  docker_sets:
+    - set: docker/ubuntu-14.04
+    - set: docker/centos-7
+    - set: docker/debian-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,25 @@ script:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/debian-8 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.2.7

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :system_tests do
   end
   gem 'serverspec',                    :require => false
   gem 'beaker-puppet_install_helper',  :require => false
+  gem 'beaker-module_install_helper',  :require => false
 end
 
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,21 +1,7 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
-# Install Puppet
-unless ENV['RS_PROVISION'] == 'no'
-  # This will install the latest available package on el and deb based
-  # systems fail on windows and osx, and install via gem on other *nixes
-  foss_opts = { default_action: 'gem_install' }
-
-  if default.is_pe?
-    install_pe
-  else
-    install_puppet(foss_opts)
-  end
-
-  hosts.each do |host|
-    on host, "mkdir -p #{host['distmoduledir']}"
-  end
-end
+run_puppet_install_helper
 
 UNSUPPORTED_PLATFORMS = %w[AIX Solaris].freeze
 
@@ -31,7 +17,6 @@ RSpec.configure do |c|
     # Install module and dependencies
     hosts.each do |host|
       copy_module_to(host, source: proj_root, module_name: 'nodejs')
-      shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
       on host, puppet('module install puppetlabs-apt --version 2.0.1'), acceptable_exit_codes: [0, 1]
       on host, puppet('module install gentoo-portage --version 2.0.1'), acceptable_exit_codes: [0, 1]
       on host, puppet('module install chocolatey-chocolatey --version 0.5.2'), acceptable_exit_codes: [0, 1]

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,27 +1,20 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
 run_puppet_install_helper
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
+
+# Additional modules for soft deps
+install_module_from_forge('puppetlabs-apt', '>= 4.1.0 < 5.0.0')
+install_module_from_forge('stahnma-epel', '>= 1.2.0 < 2.0.0')
+install_module_from_forge('chocolatey-chocolatey', '>= 1.2.6 < 2.0.0')
+install_module_from_forge('gentoo-portage', '>= 2.0.1 < 3.0.0')
 
 UNSUPPORTED_PLATFORMS = %w[AIX Solaris].freeze
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    # Install module and dependencies
-    hosts.each do |host|
-      copy_module_to(host, source: proj_root, module_name: 'nodejs')
-      on host, puppet('module install puppetlabs-apt --version 2.0.1'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module install gentoo-portage --version 2.0.1'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module install chocolatey-chocolatey --version 0.5.2'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module install stahnma-epel --version 1.0.0'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module install treydock-gpg_key --version 0.0.3'), acceptable_exit_codes: [0, 1]
-    end
-  end
 end


### PR DESCRIPTION
This does a few things:

1. Updates `spec_helper_acceptance` to use `puppet_install_helper`
1. Updates `.travis.yml` / `.sync.yml` to run acceptance tests in CI (CentOS 7 and Ubuntu 14)
1. Verifies some extra stuff, including the package source. This will fail as of now, because of the problem mentioned in #307 / https://bugzilla.redhat.com/show_bug.cgi?id=1481008

There are still some issues that running these tests exposes. It seems like Ubuntu 16.04 installs the Ubuntu version of nodejs vs. the nodesource one; I'm not trying to fix that one (or test for it) here.