### PR TITLE
Update puppet version, deprecate some older versions of OSes

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -19,7 +18,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -27,7 +25,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -35,7 +32,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -44,13 +40,13 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
         "12.04",
         "14.04",
         "16.04"
@@ -70,7 +66,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.7.0 < 5.0.0"
+      "version_requirement": ">=4.8.0 < 6.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This removes support for RedHat and derivatives v5 and Ubuntu 10, adds support for Debian 9, and changes the Puppet version requirement to the same one used in puppet-rabbitmq (">=4.8.0 < 6.0.0").