### PR TITLE
Verify EPEL support in acceptance tests

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -32,7 +32,6 @@ describe 'nodejs class:', unless: UNSUPPORTED_PLATFORMS.include?(fact('os.family
     describe package('nodejs') do
       it { is_expected.to be_installed }
       it 'comes from the expected source' do
-        pending("This won't work until we have CentOS 7.4 because of dependency")
         pkg_output = shell(pkg_cmd)
         expect(pkg_output.stdout).to match 'epel'
       end


### PR DESCRIPTION
Now CentOS 7.4 is out this pending statement can be removed.

https://lists.centos.org/pipermail/centos-announce/2017-September/022532.html