### PR TITLE
Turn off  legacy symlinks for ubuntu 16.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,7 +74,7 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
       elsif $::operatingsystemrelease =~ /^16.04$/ {
-        $legacy_debian_symlinks    = true
+        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'


### PR DESCRIPTION
With the New version of NodeJS v6.11.3 puppet brakes the installation on ubuntu 16.04

### Content of the node packages.
- V6.11.2
```
~$ dpkg -l |grep nodejs
ii  nodejs                              6.11.2-1nodesource1~xenial1                amd64        Node.js event-based server-side javascript engine
~$ dpkg -L nodejs |grep '/usr/bin/'
/usr/bin/nodejs
/usr/bin/npm
```
- V6.11.3
```
~# dpkg -l|grep nodejs
ii  nodejs                       6.11.3-1nodesource1                   amd64        Node.js event-based server-side javascript engine

~# dpkg -L nodejs |grep '/usr/bin/'
/usr/bin/node
/usr/bin/npm
```

After puppet runs to install nodejs the node binary is a broken link. 
```
~# ls -ltra /usr/bin/node /usr/bin/nodejs  /etc/alternatives/nodejs
lrwxrwxrwx 1 root root 24 Sep 15 09:41 /usr/bin/nodejs -> /etc/alternatives/nodejs
lrwxrwxrwx 1 root root 13 Sep 15 09:41 /etc/alternatives/nodejs -> /usr/bin/node
lrwxrwxrwx 1 root root 15 Sep 15 09:41 /usr/bin/node -> /usr/bin/nodejs
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
