### PR TITLE
Allow for the macports provider to be overridden on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repository on Debian and RedHat platforms. The NodeSource Node.js package
 includes the npm binary, which makes a separate npm package unnecessary.
 
 On SUSE, ArchLinux, FreeBSD, OpenBSD and Gentoo, native packages are used. On
-Darwin, the MacPorts package is used. On Windows the packages are installed
+Darwin the default provider is MacPorts. On Windows the packages are installed
 via Chocolatey.
 
 ## Setup
@@ -66,6 +66,15 @@ Or if you wish to install a Node.js 5.x release from the NodeSource repository:
 ```puppet
 class { 'nodejs':
   repo_url_suffix => '5.x',
+}
+```
+
+For MacOS the default provider is MacPorts, however, you can override this with
+the darwin_package_provider parameter.
+
+```puppet
+class { 'nodejs':
+  darwin_package_provider => 'homebrew',
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ class { 'nodejs':
 }
 ```
 
-For MacOS the default provider is MacPorts, however, you can override this with
-the darwin_package_provider parameter.
+The default package provider is overridable for all operating systems - the
+default set for MacOS is MacPorts and Windows uses Chocolatey.
 
 ```puppet
 class { 'nodejs':
-  darwin_package_provider => 'homebrew',
+  package_provider => 'homebrew',
 }
 ```
 
@@ -84,6 +84,7 @@ When a separate npm package exists (natively or via EPEL) the Node.js developmen
 package also needs to be installed as it is a dependency for npm.
 
 Install Node.js and npm using the native packages provided by the distribution:
+(Only applicable for Ubuntu 12.04/14.04 and Fedora operating systems):
 
 ```puppet
 class { '::nodejs':
@@ -157,9 +158,6 @@ except version ranges. The title simply must be a unique, arbitrary value.
   specified as an array.
 * The user parameter is provided should you wish to run npm install or npm rm
   as a specific user.
-* If you want to use a package.json supplied by a module to install dependencies
-  (e.g. if you have a NodeJS server app), set the parameter use_package_json to true.
-  The package name is then only used for the resource name. source parameter is ignored.
 
 nodejs::npm parameters:
 
@@ -170,7 +168,6 @@ nodejs::npm parameters:
 * uninstall_options: option flags invoked during removal (optional).
 * npm_path: defaults to the value listed in `nodejs::params`
 * user: defaults to undef
-* use_package_json: read and install modules listed in package.json in target dir and install those in subdirectory node_modules (defaults to false)
 
 Examples:
 
@@ -298,16 +295,6 @@ nodejs::npm { 'express with options':
 }
 ```
 
-Install dependencies from package.json:
-
-```puppet
-nodejs::npm { 'serverapp':
-  ensure           => 'present',
-  target           => '/opt/serverapp',
-  use_package_json => true,
-}
-```
-
 Uninstall any versions of express in /opt/packages regardless of source:
 
 ```puppet
@@ -315,16 +302,6 @@ nodejs::npm { 'remove all express packages':
   ensure  => 'absent',
   package => 'express',
   target  => '/opt/packages',
-}
-```
-
-Uninstall dependencies from package.json:
-
-```puppet
-nodejs::npm { 'serverapp':
-  ensure           => 'absent',
-  target           => '/opt/serverapp',
-  use_package_json => true,
 }
 ```
 
@@ -435,7 +412,7 @@ to `present` and may also be set to `absent`.
 #### `repo_pin`
 
 Whether to perform APT pinning to pin the Node.js repository with a specific
-value. Defaults to `undef`.
+value. Defaults to `false`.
 
 #### `repo_priority`
 
@@ -468,22 +445,29 @@ the NodeSource URL structure - NodeSource might remove old versions (such as
 0.10 and 0.12) or add new ones (such as 8.x) at any time.
 
 The following are ``repo_url_suffix`` values that reflect NodeSource versions
-that were available on 2017-11-29:
+that were available on 2017-01-08:
 
-* Debian 8 (Jessie) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Debian 9 (Stretch) ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Debian (Sid) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Ubuntu 14.04 (Trusty) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x``` ```8.x```
-* Ubuntu 17.10 (Artful) ```4.x``` ```6.x``` ```8.x``` ```9.x```
+* Debian 7 (Wheezy) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
+* Debian 8 (Jessie) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* Debian (Sid) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* Ubuntu 10.04 (Lucid) ```0.10```
+* Ubuntu 12.04 (Precise) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
+* Ubuntu 13.10 (Saucy) ```0.10```
+* Ubuntu 14.04 (Trusty) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* Ubuntu 14.10 (Utopic) ```0.10``` ```0.12```
+* Ubuntu 15.04 (Vivid) ```0.10``` ```0.12``` ```4.x``` ```5.x```
+* Ubuntu 15.10 (wily) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
+* Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x```
 * RHEL/CentOS 5 ```0.10``` ```0.12```
-* RHEL/CentOS 6 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* RHEL/CentOS 7 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* RHEL/CentOS 6 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* RHEL/CentOS 7 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
 * Amazon Linux - See RHEL/CentOS 7
-* Fedora 25 ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Fedora 26 ```6.x``` ```8.x``` ```9.x```
-* Fedora 27 ```8.x``` ```9.x```
+* Fedora 19/20 ```0.10``` ```0.12``` ```4.x```
+* Fedora 21 ```0.10``` ```0.12``` ```4.x``` ```5.x```
+* Fedora 22 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
+* Fedora 23/24 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* Fedora 25 ```4.x``` ```6.x``` ```7.x```
 
 #### `use_flags`
 
@@ -494,22 +478,24 @@ The USE flags to use for the Node.js package on Gentoo systems. Defaults to
 
 This module has received limited testing on:
 
-* CentOS/RHEL 6/7
-* Debian 8
-* Ubuntu 14.04
+* CentOS/RHEL 5/6/7
+* Debian 7
+* Fedora 20/21
+* Ubuntu 10.04/12.04/14.04
 
 The following platforms should also work, but have not been tested:
 
 * Amazon Linux
 * Archlinux
 * Darwin
-* Debian 9
-* Fedora
+* Debian 8
 * FreeBSD
 * Gentoo
 * OpenBSD
 * OpenSuse/SLES
 * Windows
+
+This module is not supported on Debian Squeeze.
 
 ### Module dependencies
 
@@ -532,4 +518,14 @@ wish to use this functionality, Git needs to be installed and be in the
 
 ## Development
 
-See [CONTRIBUTING](CONTRIBUTING.md)
+Puppet Labs modules on the Puppet Forge are open projects, and community
+contributions are essential for keeping them great. We can’t access the huge
+number of platforms and myriad of hardware, software, and deployment
+configurations that Puppet is intended to serve.
+
+We want to keep it as easy as possible to contribute changes so that our
+modules work in your environment. There are a few guidelines that we need
+contributors to follow so that we can have a chance of keeping on top of
+things.
+
+Read the complete module [contribution guide](https://docs.puppetlabs.com/forge/contributing.html)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repository on Debian and RedHat platforms. The NodeSource Node.js package
 includes the npm binary, which makes a separate npm package unnecessary.
 
 On SUSE, ArchLinux, FreeBSD, OpenBSD and Gentoo, native packages are used. On
-Darwin the default provider is MacPorts. On Windows the packages are installed
+Darwin, the MacPorts package is used. On Windows the packages are installed
 via Chocolatey.
 
 ## Setup
@@ -69,22 +69,12 @@ class { 'nodejs':
 }
 ```
 
-The default package provider is overridable for all operating systems - the
-default set for MacOS is MacPorts and Windows uses Chocolatey.
-
-```puppet
-class { 'nodejs':
-  package_provider => 'homebrew',
-}
-```
-
 ## Usage
 
 When a separate npm package exists (natively or via EPEL) the Node.js development
 package also needs to be installed as it is a dependency for npm.
 
 Install Node.js and npm using the native packages provided by the distribution:
-(Only applicable for Ubuntu 12.04/14.04 and Fedora operating systems):
 
 ```puppet
 class { '::nodejs':
@@ -158,6 +148,9 @@ except version ranges. The title simply must be a unique, arbitrary value.
   specified as an array.
 * The user parameter is provided should you wish to run npm install or npm rm
   as a specific user.
+* If you want to use a package.json supplied by a module to install dependencies
+  (e.g. if you have a NodeJS server app), set the parameter use_package_json to true.
+  The package name is then only used for the resource name. source parameter is ignored.
 
 nodejs::npm parameters:
 
@@ -168,6 +161,7 @@ nodejs::npm parameters:
 * uninstall_options: option flags invoked during removal (optional).
 * npm_path: defaults to the value listed in `nodejs::params`
 * user: defaults to undef
+* use_package_json: read and install modules listed in package.json in target dir and install those in subdirectory node_modules (defaults to false)
 
 Examples:
 
@@ -295,6 +289,16 @@ nodejs::npm { 'express with options':
 }
 ```
 
+Install dependencies from package.json:
+
+```puppet
+nodejs::npm { 'serverapp':
+  ensure           => 'present',
+  target           => '/opt/serverapp',
+  use_package_json => true,
+}
+```
+
 Uninstall any versions of express in /opt/packages regardless of source:
 
 ```puppet
@@ -302,6 +306,16 @@ nodejs::npm { 'remove all express packages':
   ensure  => 'absent',
   package => 'express',
   target  => '/opt/packages',
+}
+```
+
+Uninstall dependencies from package.json:
+
+```puppet
+nodejs::npm { 'serverapp':
+  ensure           => 'absent',
+  target           => '/opt/serverapp',
+  use_package_json => true,
 }
 ```
 
@@ -412,7 +426,7 @@ to `present` and may also be set to `absent`.
 #### `repo_pin`
 
 Whether to perform APT pinning to pin the Node.js repository with a specific
-value. Defaults to `false`.
+value. Defaults to `undef`.
 
 #### `repo_priority`
 
@@ -445,57 +459,53 @@ the NodeSource URL structure - NodeSource might remove old versions (such as
 0.10 and 0.12) or add new ones (such as 8.x) at any time.
 
 The following are ``repo_url_suffix`` values that reflect NodeSource versions
-that were available on 2017-01-08:
+that were available on 2017-11-29:
 
-* Debian 7 (Wheezy) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
-* Debian 8 (Jessie) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
-* Debian (Sid) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
-* Ubuntu 10.04 (Lucid) ```0.10```
-* Ubuntu 12.04 (Precise) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
-* Ubuntu 13.10 (Saucy) ```0.10```
-* Ubuntu 14.04 (Trusty) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
-* Ubuntu 14.10 (Utopic) ```0.10``` ```0.12```
-* Ubuntu 15.04 (Vivid) ```0.10``` ```0.12``` ```4.x``` ```5.x```
-* Ubuntu 15.10 (wily) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
-* Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
-* Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x```
+* Debian 8 (Jessie) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* Debian 9 (Stretch) ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* Debian (Sid) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* Ubuntu 14.04 (Trusty) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x``` ```8.x```
+* Ubuntu 17.10 (Artful) ```4.x``` ```6.x``` ```8.x``` ```9.x```
 * RHEL/CentOS 5 ```0.10``` ```0.12```
-* RHEL/CentOS 6 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
-* RHEL/CentOS 7 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
+* RHEL/CentOS 6 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* RHEL/CentOS 7 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Amazon Linux - See RHEL/CentOS 7
-* Fedora 19/20 ```0.10``` ```0.12``` ```4.x```
-* Fedora 21 ```0.10``` ```0.12``` ```4.x``` ```5.x```
-* Fedora 22 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
-* Fedora 23/24 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x```
-* Fedora 25 ```4.x``` ```6.x``` ```7.x```
+* Fedora 25 ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
+* Fedora 26 ```6.x``` ```8.x``` ```9.x```
+* Fedora 27 ```8.x``` ```9.x```
 
 #### `use_flags`
 
 The USE flags to use for the Node.js package on Gentoo systems. Defaults to
 ['npm', 'snapshot'].
 
+#### `package_provider`
+
+The package provider is set as the default for most distributions. You can override
+this with the package_provider parameter to use an alternative
+
 ## Limitations
 
 This module has received limited testing on:
 
-* CentOS/RHEL 5/6/7
-* Debian 7
-* Fedora 20/21
-* Ubuntu 10.04/12.04/14.04
+* CentOS/RHEL 6/7
+* Debian 8
+* Ubuntu 14.04
 
 The following platforms should also work, but have not been tested:
 
 * Amazon Linux
 * Archlinux
 * Darwin
-* Debian 8
+* Debian 9
+* Fedora
 * FreeBSD
 * Gentoo
 * OpenBSD
 * OpenSuse/SLES
 * Windows
-
-This module is not supported on Debian Squeeze.
 
 ### Module dependencies
 
@@ -518,14 +528,4 @@ wish to use this functionality, Git needs to be installed and be in the
 
 ## Development
 
-Puppet Labs modules on the Puppet Forge are open projects, and community
-contributions are essential for keeping them great. We can’t access the huge
-number of platforms and myriad of hardware, software, and deployment
-configurations that Puppet is intended to serve.
-
-We want to keep it as easy as possible to contribute changes so that our
-modules work in your environment. There are a few guidelines that we need
-contributors to follow so that we can have a chance of keeping on top of
-things.
-
-Read the complete module [contribution guide](https://docs.puppetlabs.com/forge/contributing.html)
+See [CONTRIBUTING](CONTRIBUTING.md)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,12 @@ class nodejs(
   $repo_proxy_username                                 = $nodejs::params::repo_proxy_username,
   $repo_url_suffix                                     = $nodejs::params::repo_url_suffix,
   Array $use_flags                                     = $nodejs::params::use_flags,
+  String $darwin_package_provider                      = $nodejs::params::darwin_package_provider,
 ) inherits nodejs::params {
+
+  if $facts['osfamily'] == 'Darwin' {
+    Package { provider => $darwin_package_provider }
+  }
 
   if $manage_package_repo and !$repo_class {
     fail("${module_name}: The manage_package_repo parameter was set to true but no repo_class was provided.")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,12 +23,8 @@ class nodejs(
   $repo_proxy_username                                 = $nodejs::params::repo_proxy_username,
   $repo_url_suffix                                     = $nodejs::params::repo_url_suffix,
   Array $use_flags                                     = $nodejs::params::use_flags,
-  String $darwin_package_provider                      = $nodejs::params::darwin_package_provider,
+  Optional[String] $package_provider                   = $nodejs::params::package_provider,
 ) inherits nodejs::params {
-
-  if $facts['osfamily'] == 'Darwin' {
-    Package { provider => $darwin_package_provider }
-  }
 
   if $manage_package_repo and !$repo_class {
     fail("${module_name}: The manage_package_repo parameter was set to true but no repo_class was provided.")

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,8 +18,9 @@ class nodejs::install {
     }
   }
 
+  Package { provider => $nodejs::package_provider }
   # nodejs
-  package { $nodejs::nodejs_package_name:
+  -> package { $nodejs::nodejs_package_name:
     ensure => $nodejs::nodejs_package_ensure,
     tag    => 'nodesource_repo',
   }
@@ -51,7 +52,7 @@ class nodejs::install {
   if $facts['osfamily'] == 'Darwin' {
     $root_npmrc_path = '/var/root'
   } else {
-    $root_npmrc_path = '/root'
+    $root_npmrc_path = $facts['root_home']
   }
 
   file { 'root_npmrc':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,7 +56,7 @@ class nodejs::install {
 
   file { 'root_npmrc':
     ensure  => 'file',
-    path    => '/root/.npmrc',
+    path    => "${root_npmrc_path}/.npmrc",
     content => template('nodejs/npmrc.erb'),
     owner   => 'root',
     group   => '0',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,6 +48,12 @@ class nodejs::install {
     }
   }
 
+  if $facts['osfamily'] == 'Darwin' {
+    $root_npmrc_path = '/var/root'
+  } else {
+    $root_npmrc_path = '/root'
+  }
+
   file { 'root_npmrc':
     ensure  => 'file',
     path    => '/root/.npmrc',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,9 +18,8 @@ class nodejs::install {
     }
   }
 
-  if $nodejs::package_provider != undef {
-    Package { provider => $nodejs::package_provider }
-  }
+  Package { provider => $nodejs::package_provider }
+
   # nodejs
   package { $nodejs::nodejs_package_name:
     ensure => $nodejs::nodejs_package_ensure,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,7 @@ class nodejs::install {
 
   Package { provider => $nodejs::package_provider }
   # nodejs
-  -> package { $nodejs::nodejs_package_name:
+  package { $nodejs::nodejs_package_name:
     ensure => $nodejs::nodejs_package_ensure,
     tag    => 'nodesource_repo',
   }
@@ -49,11 +49,7 @@ class nodejs::install {
     }
   }
 
-  if $facts['osfamily'] == 'Darwin' {
-    $root_npmrc_path = '/var/root'
-  } else {
-    $root_npmrc_path = $facts['root_home']
-  }
+  $root_npmrc_path = $facts['root_home']
 
   file { 'root_npmrc':
     ensure  => 'file',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,9 @@ class nodejs::install {
     }
   }
 
-  Package { provider => $nodejs::package_provider }
+  if $nodejs::package_provider != undef {
+    Package { provider => $nodejs::package_provider }
+  }
   # nodejs
   package { $nodejs::nodejs_package_name:
     ensure => $nodejs::nodejs_package_ensure,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,11 +50,9 @@ class nodejs::install {
     }
   }
 
-  $root_npmrc_path = $facts['root_home']
-
   file { 'root_npmrc':
     ensure  => 'file',
-    path    => "${root_npmrc_path}/.npmrc",
+    path    => "${facts['root_home']}/.npmrc",
     content => template('nodejs/npmrc.erb'),
     owner   => 'root',
     group   => '0',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,7 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
 
-      $package_provider          = 'apt'
+      $package_provider          = undef
     }
     'RedHat': {
       if $facts['os']['release']['major'] =~ /^[67]$/ {
@@ -68,7 +68,6 @@ class nodejs::params {
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
-        $package_provider          = 'yum'
       }
       elsif $facts['os']['name'] == 'Fedora' {
         $manage_package_repo       = true
@@ -80,7 +79,6 @@ class nodejs::params {
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
-        $package_provider           = 'yum'
       }
       elsif ($facts['os']['name'] == 'Amazon') {
         $manage_package_repo       = true
@@ -92,11 +90,11 @@ class nodejs::params {
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
-        $package_provider          = 'yum'
       }
       else {
         fail("The ${module_name} module is not supported on ${::operatingsystem} ${::operatingsystemrelease}.")
       }
+      $package_provider          = undef
     }
     'Suse': {
       $manage_package_repo       = false
@@ -108,7 +106,7 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
-      $package_provider          = 'zypper'
+      $package_provider          = undef
     }
     'Archlinux': {
       $manage_package_repo       = false
@@ -120,7 +118,7 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
-      $package_provider          = 'pacman'
+      $package_provider          = undef
     }
     'FreeBSD': {
       $manage_package_repo       = false
@@ -132,7 +130,7 @@ class nodejs::params {
       $npm_package_name          = 'www/npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
-      $package_provider          = 'pacman'
+      $package_provider          = undef
     }
     'OpenBSD': {
       $manage_package_repo       = false
@@ -144,7 +142,7 @@ class nodejs::params {
       $npm_package_name          = false
       $npm_path                  = '/usr/local/bin/npm'
       $repo_class                = undef
-      $package_provider          = 'openbsd'
+      $package_provider          = undef
     }
     'Darwin': {
       $manage_package_repo       = false
@@ -180,7 +178,7 @@ class nodejs::params {
       $npm_package_name          = false
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
-      $package_provider          = 'portage'
+      $package_provider          = undef
     }
     default: {
       fail("The ${module_name} module is not supported on a ${facts['os']['name']} distribution.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,6 @@ class nodejs::params {
   $repo_proxy_username         = 'absent'
   $repo_url_suffix             = '0.10'
   $use_flags                   = ['npm', 'snapshot']
-  $darwin_package_provider     = 'macports'
 
   $cmd_exe_path = $facts['os']['family'] ? {
     'Windows' => "${facts['os']['windows']['system32']}\\cmd.exe",
@@ -55,6 +54,8 @@ class nodejs::params {
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
       }
+
+      $package_provider          = 'apt'
     }
     'RedHat': {
       if $facts['os']['release']['major'] =~ /^[67]$/ {
@@ -67,6 +68,7 @@ class nodejs::params {
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
+        $package_provider          = 'yum'
       }
       elsif $facts['os']['name'] == 'Fedora' {
         $manage_package_repo       = true
@@ -78,6 +80,7 @@ class nodejs::params {
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
+        $package_provider           = 'yum'
       }
       elsif ($facts['os']['name'] == 'Amazon') {
         $manage_package_repo       = true
@@ -89,6 +92,7 @@ class nodejs::params {
         $npm_package_name          = 'npm'
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
+        $package_provider          = 'yum'
       }
       else {
         fail("The ${module_name} module is not supported on ${::operatingsystem} ${::operatingsystemrelease}.")
@@ -104,6 +108,7 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
+      $package_provider          = 'zypper'
     }
     'Archlinux': {
       $manage_package_repo       = false
@@ -115,6 +120,7 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
+      $package_provider          = 'pacman'
     }
     'FreeBSD': {
       $manage_package_repo       = false
@@ -126,6 +132,7 @@ class nodejs::params {
       $npm_package_name          = 'www/npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
+      $package_provider          = 'pacman'
     }
     'OpenBSD': {
       $manage_package_repo       = false
@@ -137,6 +144,7 @@ class nodejs::params {
       $npm_package_name          = false
       $npm_path                  = '/usr/local/bin/npm'
       $repo_class                = undef
+      $package_provider          = 'openbsd'
     }
     'Darwin': {
       $manage_package_repo       = false
@@ -148,6 +156,7 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '/opt/local/bin/npm'
       $repo_class                = undef
+      $package_provider          = 'macports'
     }
     'Windows': {
       $manage_package_repo       = false
@@ -159,7 +168,7 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '"C:\Program Files\nodejs\npm.cmd"'
       $repo_class                = undef
-      Package { provider => 'chocolatey' }
+      $package_provider          = 'chocolatey'
     }
     'Gentoo': {
       $manage_package_repo       = false
@@ -171,6 +180,7 @@ class nodejs::params {
       $npm_package_name          = false
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
+      $package_provider          = 'portage'
     }
     default: {
       fail("The ${module_name} module is not supported on a ${facts['os']['name']} distribution.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class nodejs::params {
   $repo_proxy_username         = 'absent'
   $repo_url_suffix             = '0.10'
   $use_flags                   = ['npm', 'snapshot']
+  $darwin_package_provider     = 'macports'
 
   $cmd_exe_path = $facts['os']['family'] ? {
     'Windows' => "${facts['os']['windows']['system32']}\\cmd.exe",
@@ -147,7 +148,6 @@ class nodejs::params {
       $npm_package_name          = 'npm'
       $npm_path                  = '/opt/local/bin/npm'
       $repo_class                = undef
-      Package { provider => 'macports' }
     }
     'Windows': {
       $manage_package_repo       = false

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -889,6 +889,16 @@ describe 'nodejs', type: :class do
       }
     end
 
+    it 'the file resource root_npmrc should use /var/root for the path' do
+      is_expected.to contain_file('root_npmrc').with(
+        'ensure' => 'file',
+        'path'    => '/var/root/.npmrc',
+        'owner'   => 'root',
+        'group'   => '0',
+        'mode'    => '0600'
+      )
+    end
+
     # nodejs_dev_package_ensure
     context 'with nodejs_dev_package_ensure set to present' do
       let :params do

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -18,7 +18,7 @@ describe 'nodejs', type: :class do
       it 'the file resource root_npmrc should be in the catalog' do
         is_expected.to contain_file('root_npmrc').with(
           'ensure' => 'file',
-          'path'    => '/root/.npmrc',
+          'path'    => '/.npmrc',
           'owner'   => 'root',
           'group'   => '0',
           'mode'    => '0600'
@@ -892,7 +892,7 @@ describe 'nodejs', type: :class do
     it 'the file resource root_npmrc should use /var/root for the path' do
       is_expected.to contain_file('root_npmrc').with(
         'ensure' => 'file',
-        'path'    => '/var/root/.npmrc',
+        'path'    => '/.npmrc',
         'owner'   => 'root',
         'group'   => '0',
         'mode'    => '0600'
@@ -974,16 +974,16 @@ describe 'nodejs', type: :class do
       end
     end
 
-    context 'with the darwin_package_provider left as default' do
+    context 'with the package_provider left as default' do
       it 'uses Macports as the default provider' do
         is_expected.to contain_package('nodejs').with('provider' => 'macports')
       end
     end
 
-    context 'with the darwin_package_provider set to homebrew' do
+    context 'with the package_provider set to homebrew' do
       let :params do
         {
-          darwin_package_provider: 'homebrew'
+          package_provider: 'homebrew'
         }
       end
 

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -18,7 +18,7 @@ describe 'nodejs', type: :class do
       it 'the file resource root_npmrc should be in the catalog' do
         is_expected.to contain_file('root_npmrc').with(
           'ensure' => 'file',
-          'path'    => '/.npmrc',
+          'path'    => '/root/.npmrc',
           'owner'   => 'root',
           'group'   => '0',
           'mode'    => '0600'
@@ -887,16 +887,6 @@ describe 'nodejs', type: :class do
           'name' => 'Darwin'
         }
       }
-    end
-
-    it 'the file resource root_npmrc should use /var/root for the path' do
-      is_expected.to contain_file('root_npmrc').with(
-        'ensure' => 'file',
-        'path'    => '/.npmrc',
-        'owner'   => 'root',
-        'group'   => '0',
-        'mode'    => '0600'
-      )
     end
 
     # nodejs_dev_package_ensure

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -963,6 +963,24 @@ describe 'nodejs', type: :class do
         is_expected.to contain_package('npm').with('ensure' => 'absent')
       end
     end
+
+    context 'with the darwin_package_provider left as default' do
+      it 'uses Macports as the default provider' do
+        is_expected.to contain_package('nodejs').with('provider' => 'macports')
+      end
+    end
+
+    context 'with the darwin_package_provider set to homebrew' do
+      let :params do
+        {
+          darwin_package_provider: 'homebrew'
+        }
+      end
+
+      it 'uses homebrew as the default provider' do
+        is_expected.to contain_package('nodejs').with('provider' => 'homebrew')
+      end
+    end
   end
 
   context 'when running on Windows' do

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -12,3 +12,4 @@ concat_basedir: "/tmp"
 ipaddress: "172.16.254.254"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+root_home: /root

--- a/spec/default_module_facts.yaml
+++ b/spec/default_module_facts.yaml
@@ -1,0 +1,2 @@
+---
+root_home: /root


### PR DESCRIPTION
A vague pondering on how to fix this issue - not sure its 100% working or if my macvm is not happy about npm for other reasons. But any thoughts?