### PR TITLE
Allow all Fedora versions to use NodeSource

### DIFF
--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -28,7 +28,7 @@ class nodejs::repo::nodesource {
       }
 
       # Fedora
-      elsif $::operatingsystemrelease =~ /(19)|(20)|(21)|(22)|(23)/ and $::operatingsystem == 'Fedora' {
+      elsif $::operatingsystem == 'Fedora' {
         $dist_version  = $::operatingsystemrelease
         $name_string   = "Fedora Core ${::operatingsystemrelease}"
       }


### PR DESCRIPTION
Don't restrict what versions can use the NodeSource repository