### PR TITLE
Set default value for $repo_pin to undef

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ to `present` and may also be set to `absent`.
 #### `repo_pin`
 
 Whether to perform APT pinning to pin the Node.js repository with a specific
-value. Defaults to `false`.
+value. Defaults to `undef`.
 
 #### `repo_priority`
 
@@ -521,7 +521,7 @@ This module is not supported on Debian Squeeze.
 
 This modules uses `puppetlabs-apt` for the management of the NodeSource
 repository. If using an operating system of the Debian-based family, you will
-need to ensure that `puppetlabs-apt` version 2.x is installed.
+need to ensure that `puppetlabs-apt` version 2.x or above is installed.
 
 If using CentoOS/RHEL 5, you will need to ensure that the `stahnma-epel`
 module is installed.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class nodejs::params {
   $nodejs_package_ensure       = 'present'
   $repo_enable_src             = false
   $repo_ensure                 = 'present'
-  $repo_pin                    = false
+  $repo_pin                    = undef
   $repo_priority               = 'absent'
   $repo_proxy                  = 'absent'
   $repo_proxy_password         = 'absent'

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -124,11 +124,11 @@ describe 'nodejs', type: :class do
 
         context 'and repo_pin not set' do
           let :params do
-            default_params.merge!(repo_pin: 'false')
+            default_params.merge!(repo_pin: :undef)
           end
 
-          it 'the repo apt::source resource should contain pin = false' do
-            is_expected.to contain_apt__source('nodesource').with('pin' => 'false')
+          it 'the repo apt::source resource should contain pin = undef' do
+            is_expected.to contain_apt__source('nodesource').with('pin' => nil)
           end
         end
 


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-apt/pull/711 introduced data types in the apt module, and false is no longer a valid value for the apt::source $pin parameter

Fixes #333