### PR TITLE
Enhance distro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,16 @@ that were available on 2017-11-14:
 * Fedora 25 ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Fedora 26 ```6.x``` ```8.x``` ```9.x```
 
+#### `repo_release`
+
+Option to override the apt distro release.  Defaults to undef which will 
+autodetect the distro, if specified will influence the apt repo distro.
+This is useful if the distro name does not exist in the nodejs repos, for
+example a derivative distribution.
+eg. Ubilinux 4 distro release name is 'dolcetto' which does not exist in
+nodejs repos, but is a derivative of Debian 9 'stretch'.  Setting this
+param to 'stretch' therefore allows this repo management to work as expected.
+
 #### `use_flags`
 
 The USE flags to use for the Node.js package on Gentoo systems. Defaults to

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class nodejs(
   $repo_proxy_password                                 = $nodejs::params::repo_proxy_password,
   $repo_proxy_username                                 = $nodejs::params::repo_proxy_username,
   $repo_url_suffix                                     = $nodejs::params::repo_url_suffix,
+  $repo_release                                        = $nodejs::params::repo_release,
   Array $use_flags                                     = $nodejs::params::use_flags,
 ) inherits nodejs::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class nodejs(
   $repo_proxy_password                                 = $nodejs::params::repo_proxy_password,
   $repo_proxy_username                                 = $nodejs::params::repo_proxy_username,
   $repo_url_suffix                                     = $nodejs::params::repo_url_suffix,
-  $repo_release                                        = $nodejs::params::repo_release,
+  Optional[String] $repo_release                       = $nodejs::params::repo_release,
   Array $use_flags                                     = $nodejs::params::use_flags,
 ) inherits nodejs::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class nodejs::params {
       if $::operatingsystemrelease =~ /^6\.(\d+)/ {
         fail("The ${module_name} module is not supported on Debian Squeeze.")
       }
-      elsif $::operatingsystemrelease =~ /^[78]\.(\d+)/ {
+      elsif $::operatingsystemrelease =~ /^[789]\.(\d+)/ {
         $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class nodejs::params {
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
   $repo_url_suffix             = '0.10'
+  $repo_release                = $::lsbdistcodename
   $use_flags                   = ['npm', 'snapshot']
 
   # The full path to cmd.exe is required on Windows. The system32 fact is only

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class nodejs::params {
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
   $repo_url_suffix             = '0.10'
-  $repo_release                = $::lsbdistcodename
+  $repo_release                = undef
   $use_flags                   = ['npm', 'snapshot']
 
   # The full path to cmd.exe is required on Windows. The system32 fact is only

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -8,6 +8,7 @@ class nodejs::repo::nodesource {
   $proxy_password = $nodejs::repo_proxy_password
   $proxy_username = $nodejs::repo_proxy_username
   $url_suffix     = $nodejs::repo_url_suffix
+  $release        = $nodejs::repo_release
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -22,7 +22,7 @@ class nodejs::repo::nodesource::apt {
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
-      release  => pick($release, $::lsbdistcodename),
+      release  => $release,
       repos    => 'main',
       require  => [
         Package['apt-transport-https'],

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -11,12 +11,6 @@ class nodejs::repo::nodesource::apt {
 
   include ::apt
 
-  if empty($release) {
-    $_release = $::lsbdistcodename
-  } else {
-    $_release = $release
-  }
-  
   if ($ensure != 'absent') {
     apt::source { 'nodesource':
       include  => {
@@ -28,7 +22,7 @@ class nodejs::repo::nodesource::apt {
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
-      release  => $_release,
+      release  => pick($release, $::lsbdistcodename),
       repos    => 'main',
       require  => [
         Package['apt-transport-https'],

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -11,6 +11,12 @@ class nodejs::repo::nodesource::apt {
 
   include ::apt
 
+  if empty($release) {
+    $_release = $::lsbdistcodename
+  } else {
+    $_release = $release
+  }
+  
   if ($ensure != 'absent') {
     apt::source { 'nodesource':
       include  => {
@@ -22,7 +28,7 @@ class nodejs::repo::nodesource::apt {
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
-      release  => $release,
+      release  => $_release,
       repos    => 'main',
       require  => [
         Package['apt-transport-https'],

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -5,6 +5,7 @@ class nodejs::repo::nodesource::apt {
   $ensure     = $nodejs::repo::nodesource::ensure
   $pin        = $nodejs::repo::nodesource::pin
   $url_suffix = $nodejs::repo::nodesource::url_suffix
+  $release    = $nodejs::repo::nodesource::release
 
   ensure_packages(['apt-transport-https', 'ca-certificates'])
 
@@ -21,7 +22,7 @@ class nodejs::repo::nodesource::apt {
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
-      release  => $::lsbdistcodename,
+      release  => $release,
       repos    => 'main',
       require  => [
         Package['apt-transport-https'],


### PR DESCRIPTION
Add explicit Debian 9 (stretch) support, and add support for Ubilinux.

Ubilinux 4 (that supports all variants of the Up boards) is a derivative of Debian 9.  However it reports dolcetto as the lsbdistcodename instead of stretch so the nodejs repo fails.  This PR adds support for a $nodejs::repo_release parameter that allows the distro code name to be specified rather than blindly taking it from lsbdistcodename.

eg.:
```
    class { 'nodejs':
        repo_url_suffix => '8.x',
        repo_release    => 'stretch',
        nodejs_package_ensure => latest,
    }
```
