### PR TITLE
Remove EOL operating systems, Legacy facts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ When a separate npm package exists (natively or via EPEL) the Node.js developmen
 package also needs to be installed as it is a dependency for npm.
 
 Install Node.js and npm using the native packages provided by the distribution:
-(Only applicable for Ubuntu 12.04/14.04 and Fedora operating systems):
 
 ```puppet
 class { '::nodejs':
@@ -470,13 +469,11 @@ the NodeSource URL structure - NodeSource might remove old versions (such as
 0.10 and 0.12) or add new ones (such as 8.x) at any time.
 
 The following are ``repo_url_suffix`` values that reflect NodeSource versions
-that were available on 2017-11-14:
+that were available on 2017-11-29:
 
-* Debian 7 (Wheezy) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
 * Debian 8 (Jessie) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Debian 9 (Stretch) ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Debian (Sid) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
-* Ubuntu 12.04 (Precise) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x```
 * Ubuntu 14.04 (Trusty) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x``` ```8.x```
@@ -487,6 +484,7 @@ that were available on 2017-11-14:
 * Amazon Linux - See RHEL/CentOS 7
 * Fedora 25 ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Fedora 26 ```6.x``` ```8.x``` ```9.x```
+* Fedora 27 ```8.x``` ```9.x```
 
 #### `use_flags`
 
@@ -497,23 +495,22 @@ The USE flags to use for the Node.js package on Gentoo systems. Defaults to
 
 This module has received limited testing on:
 
-* CentOS/RHEL 5/6/7
-* Debian 7
-* Ubuntu 10.04/12.04/14.04
+* CentOS/RHEL 6/7
+* Debian 8
+* Ubuntu 14.04
 
 The following platforms should also work, but have not been tested:
 
 * Amazon Linux
 * Archlinux
 * Darwin
-* Debian 8
+* Debian 9
+* Fedora
 * FreeBSD
 * Gentoo
 * OpenBSD
 * OpenSuse/SLES
 * Windows
-
-This module is not supported on Debian Squeeze.
 
 ### Module dependencies
 
@@ -521,10 +518,7 @@ This modules uses `puppetlabs-apt` for the management of the NodeSource
 repository. If using an operating system of the Debian-based family, you will
 need to ensure that `puppetlabs-apt` version 2.x or above is installed.
 
-If using CentoOS/RHEL 5, you will need to ensure that the `stahnma-epel`
-module is installed.
-
-If using CentoOS/RHEL 5/6/7 and you wish to install Node.js from EPEL rather
+If using CentOS/RHEL 6/7 and you wish to install Node.js from EPEL rather
 than from the NodeSource repository, you will need to ensure `stahnma-epel` is
 installed and is applied before this module.
 
@@ -539,14 +533,4 @@ wish to use this functionality, Git needs to be installed and be in the
 
 ## Development
 
-Puppet Labs modules on the Puppet Forge are open projects, and community
-contributions are essential for keeping them great. We can’t access the huge
-number of platforms and myriad of hardware, software, and deployment
-configurations that Puppet is intended to serve.
-
-We want to keep it as easy as possible to contribute changes so that our
-modules work in your environment. There are a few guidelines that we need
-contributors to follow so that we can have a chance of keeping on top of
-things.
-
-Read the complete module [contribution guide](https://docs.puppetlabs.com/forge/contributing.html)
+See [CONTRIBUTING](CONTRIBUTING.md)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class nodejs::install {
   }
 
   # npm is a Gentoo USE flag
-  if $::operatingsystem == 'Gentoo' {
+  if $facts['os']['name'] == 'Gentoo' {
     package_use { $nodejs::nodejs_package_name:
       ensure => present,
       target => 'nodejs-flags',
@@ -41,7 +41,7 @@ class nodejs::install {
   }
 
   # Replicates the nodejs-legacy package functionality
-  if ($::osfamily == 'Debian' and $nodejs::legacy_debian_symlinks) {
+  if ($facts['os']['family'] == 'Debian' and $nodejs::legacy_debian_symlinks) {
     file { '/usr/bin/node':
       ensure => 'link',
       target => '/usr/bin/nodejs',

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -33,12 +33,12 @@ define nodejs::npm (
     $package_string = "${package}@${ensure}"
   }
 
-  $grep_command = $::osfamily ? {
+  $grep_command = $facts['os']['family'] ? {
     'Windows' => "${cmd_exe_path} /c findstr /l",
     default   => 'grep',
   }
 
-  $dirsep = $::osfamily ? {
+  $dirsep = $facts['os']['family'] ? {
     'Windows' => "\\",
     default   => '/'
   }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -2,12 +2,18 @@ require 'spec_helper'
 
 describe 'nodejs', type: :class do
   on_supported_os.each do |os, facts|
-    next unless facts[:osfamily] == 'Debian'
+    next unless facts[:os]['family'] == 'Debian'
 
     context "on #{os} " do
       let :facts do
         facts
       end
+
+      is_supported_debian_version = if facts[:os]['family'] == 'Debian' && %w[8 9].include?(facts[:os]['release']['major'])
+                                      true
+                                    else
+                                      false
+                                    end
 
       it 'the file resource root_npmrc should be in the catalog' do
         is_expected.to contain_file('root_npmrc').with(
@@ -208,10 +214,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if facts[:osfamily] == 'Debian' && (
-             facts[:operatingsystemrelease] == '10.04' ||
-             %w[7 8].include?(facts[:operatingsystemmajrelease])
-        )
+        if is_supported_debian_version
+
           it 'the nodejs development package resource should not be present' do
             is_expected.not_to contain_package('nodejs-dev')
           end
@@ -229,10 +233,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if facts[:osfamily] == 'Debian' && (
-             facts[:operatingsystemrelease] == '10.04' ||
-             %w[7 8].include?(facts[:operatingsystemmajrelease])
-        )
+        if is_supported_debian_version
+
           it 'the nodejs development package resource should not be present' do
             is_expected.not_to contain_package('nodejs-dev')
           end
@@ -276,10 +278,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if facts[:osfamily] == 'Debian' && (
-             facts[:operatingsystemrelease] == '10.04' ||
-             %w[7 8].include?(facts[:operatingsystemmajrelease])
-        )
+        if is_supported_debian_version
+
           it 'the npm package resource should not be present' do
             is_expected.not_to contain_package('npm')
           end
@@ -297,10 +297,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if facts[:osfamily] == 'Debian' && (
-             facts[:operatingsystemrelease] == '10.04' ||
-             %w[7 8].include?(facts[:operatingsystemmajrelease])
-        )
+        if is_supported_debian_version
+
           it 'the npm package resource should not be present' do
             is_expected.not_to contain_package('npm')
           end
@@ -326,25 +324,11 @@ describe 'nodejs', type: :class do
     end
   end
 
-  context 'when run on an unsupported version of Fedora (18)' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'Fedora',
-        operatingsystemrelease: '18'
-      }
-    end
-
-    it do
-      expect { catalogue }.to raise_error(Puppet::Error, %r{The nodejs module is not supported on Fedora 18.})
-    end
-  end
-
-  ['5.0', '6.0', '7.0', '25'].each do |operatingsystemrelease|
+  ['6.0', '7.0', '27'].each do |operatingsystemrelease|
     osversions = operatingsystemrelease.split('.')
     operatingsystemmajrelease = osversions[0]
 
-    if operatingsystemrelease =~ %r{^[5-7]\.(\d+)}
+    if operatingsystemrelease =~ %r{^[6-7]\.(\d+)}
       operatingsystem     = 'CentOS'
       dist_type           = 'el'
       repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
@@ -363,10 +347,14 @@ describe 'nodejs', type: :class do
     context "when run on #{operatingsystem} release #{operatingsystemrelease}" do
       let :facts do
         {
-          operatingsystem: operatingsystem,
-          operatingsystemmajrelease: operatingsystemmajrelease,
-          operatingsystemrelease: operatingsystemrelease,
-          osfamily: 'RedHat'
+          'os' => {
+            'family' => 'RedHat',
+            'name' => operatingsystem,
+            'release' => {
+              'major' => operatingsystemmajrelease,
+              'full'  => operatingsystemrelease
+            }
+          }
         }
       end
 
@@ -656,8 +644,10 @@ describe 'nodejs', type: :class do
   context 'when running on Suse' do
     let :facts do
       {
-        osfamily: 'Suse',
-        operatingsystem: 'SLES'
+        'os' => {
+          'family' => 'Suse',
+          'name' => 'SLES'
+        }
       }
     end
 
@@ -765,8 +755,10 @@ describe 'nodejs', type: :class do
   context 'when running on Archlinux' do
     let :facts do
       {
-        osfamily: 'Archlinux',
-        operatingsystem: 'Archlinux'
+        'os' => {
+          'family' => 'Archlinux',
+          'name' => 'Archlinux'
+        }
       }
     end
 
@@ -799,8 +791,10 @@ describe 'nodejs', type: :class do
   context 'when running on FreeBSD' do
     let :facts do
       {
-        osfamily: 'FreeBSD',
-        operatingsystem: 'FreeBSD'
+        'os' => {
+          'family' => 'FreeBSD',
+          'name' => 'FreeBSD'
+        }
       }
     end
 
@@ -883,8 +877,10 @@ describe 'nodejs', type: :class do
   context 'when running on OpenBSD' do
     let :facts do
       {
-        osfamily: 'OpenBSD',
-        operatingsystem: 'OpenBSD'
+        'os' => {
+          'family' => 'OpenBSD',
+          'name' => 'OpenBSD'
+        }
       }
     end
 
@@ -917,8 +913,10 @@ describe 'nodejs', type: :class do
   context 'when running on Darwin' do
     let :facts do
       {
-        osfamily: 'Darwin',
-        operatingsystem: 'Darwin'
+        'os' => {
+          'family' => 'Darwin',
+          'name' => 'Darwin'
+        }
       }
     end
 
@@ -1001,8 +999,13 @@ describe 'nodejs', type: :class do
   context 'when running on Windows' do
     let :facts do
       {
-        osfamily: 'Windows',
-        operatingsystem: 'Windows'
+        'os' => {
+          'family' => 'Windows',
+          'name' => 'Windows',
+          'windows' => {
+            'system32' => 'C:\Windows\system32'
+          }
+        }
       }
     end
 
@@ -1059,7 +1062,12 @@ describe 'nodejs', type: :class do
 
   context 'when running on Gentoo' do
     let :facts do
-      { osfamily: 'Linux', operatingsystem: 'Gentoo' }
+      {
+        'os' => {
+          'family' => 'Gentoo',
+          'name' => 'Gentoo'
+        }
+      }
     end
 
     # nodejs_package_ensure
@@ -1100,277 +1108,18 @@ describe 'nodejs', type: :class do
     end
   end
 
-  context 'when running on Amazon Linux 2014.09' do
-    let :facts do
-      {
-        osfamily: 'Linux',
-        operatingsystem: 'Amazon',
-        operatingsystemrelease: '2014.09'
-      }
-    end
-
-    repo_baseurl        = 'https://rpm.nodesource.com/pub_0.10/el/7/$basearch'
-    repo_source_baseurl = 'https://rpm.nodesource.com/pub_0.10/el/7/SRPMS'
-    repo_descr          = 'Node.js Packages for Enterprise Linux 7 - $basearch'
-    repo_source_descr   = 'Node.js for Enterprise Linux 7 - $basearch - Source'
-
-    # manage_package_repo
-    context 'with manage_package_repo set to true' do
-      let :default_params do
-        {
-          manage_package_repo: true
-        }
-      end
-
-      context 'and repo_class set to ::nodejs::repo::nodesource' do
-        let :params do
-          default_params.merge!(repo_class: 'nodejs::repo::nodesource')
-        end
-
-        it '::nodejs::repo::nodesource should be in the catalog' do
-          is_expected.to contain_class('nodejs::repo::nodesource')
-        end
-
-        it '::nodejs::repo::nodesource::yum should be in the catalog' do
-          is_expected.to contain_class('nodejs::repo::nodesource::yum')
-        end
-
-        it 'the nodesource and nodesource-source repos should contain the right description and baseurl' do
-          is_expected.to contain_yumrepo('nodesource').with('baseurl' => repo_baseurl,
-                                                            'descr'   => repo_descr)
-
-          is_expected.to contain_yumrepo('nodesource-source').with('baseurl' => repo_source_baseurl,
-                                                                   'descr'   => repo_source_descr)
-        end
-      end
-
-      context 'and repo_enable_src set to true' do
-        let :params do
-          default_params.merge!(repo_enable_src: true)
-        end
-
-        it 'the yumrepo resource nodesource-source should contain enabled = 1' do
-          is_expected.to contain_yumrepo('nodesource-source').with('enabled' => '1')
-        end
-      end
-
-      context 'and repo_enable_src set to false' do
-        let :params do
-          default_params.merge!(repo_enable_src: false)
-        end
-
-        it 'the yumrepo resource should contain enabled = 0' do
-          is_expected.to contain_yumrepo('nodesource-source').with('enabled' => '0')
-        end
-      end
-
-      context 'and repo_ensure set to present' do
-        let :params do
-          default_params.merge!(repo_ensure: 'present')
-        end
-
-        it 'the nodesource yum repo files should exist' do
-          is_expected.to contain_yumrepo('nodesource')
-          is_expected.to contain_yumrepo('nodesource-source')
-        end
-      end
-
-      context 'and repo_ensure set to absent' do
-        let :params do
-          default_params.merge!(repo_ensure: 'absent')
-        end
-
-        it 'the nodesource yum repo files should not exist' do
-          is_expected.to contain_yumrepo('nodesource').with('enabled' => 'absent')
-          is_expected.to contain_yumrepo('nodesource-source').with('enabled' => 'absent')
-        end
-      end
-
-      context 'and repo_proxy set to absent' do
-        let :params do
-          default_params.merge!(repo_proxy: 'absent')
-        end
-
-        it 'the yumrepo resource should contain proxy = absent' do
-          is_expected.to contain_yumrepo('nodesource').with('proxy' => 'absent')
-          is_expected.to contain_yumrepo('nodesource-source').with('proxy' => 'absent')
-        end
-      end
-
-      context 'and repo_proxy set to http://proxy.localdomain.com' do
-        let :params do
-          default_params.merge!(repo_proxy: 'http://proxy.localdomain.com')
-        end
-
-        it 'the yumrepo resource should contain proxy = http://proxy.localdomain.com' do
-          is_expected.to contain_yumrepo('nodesource').with('proxy' => 'http://proxy.localdomain.com')
-          is_expected.to contain_yumrepo('nodesource-source').with('proxy' => 'http://proxy.localdomain.com')
-        end
-      end
-
-      context 'and repo_proxy_password set to absent' do
-        let :params do
-          default_params.merge!(repo_proxy_password: 'absent')
-        end
-
-        it 'the yumrepo resource should contain proxy_password = absent' do
-          is_expected.to contain_yumrepo('nodesource').with('proxy_password' => 'absent')
-          is_expected.to contain_yumrepo('nodesource-source').with('proxy_password' => 'absent')
-        end
-      end
-
-      context 'and repo_proxy_password set to password' do
-        let :params do
-          default_params.merge!(repo_proxy_password: 'password')
-        end
-
-        it 'the yumrepo resource should contain proxy_password = password' do
-          is_expected.to contain_yumrepo('nodesource').with('proxy_password' => 'password')
-          is_expected.to contain_yumrepo('nodesource-source').with('proxy_password' => 'password')
-        end
-      end
-
-      context 'and repo_proxy_username set to absent' do
-        let :params do
-          default_params.merge!(repo_proxy_username: 'absent')
-        end
-
-        it 'the yumrepo resource should contain proxy_username = absent' do
-          is_expected.to contain_yumrepo('nodesource').with('proxy_username' => 'absent')
-          is_expected.to contain_yumrepo('nodesource-source').with('proxy_username' => 'absent')
-        end
-      end
-
-      context 'and repo_proxy_username set to proxyuser' do
-        let :params do
-          default_params.merge!(repo_proxy_username: 'proxyuser')
-        end
-
-        it 'the yumrepo resource should contain proxy_username = proxyuser' do
-          is_expected.to contain_yumrepo('nodesource').with('proxy_username' => 'proxyuser')
-          is_expected.to contain_yumrepo('nodesource-source').with('proxy_username' => 'proxyuser')
-        end
-      end
-    end
-
-    context 'with manage_package_repo set to false' do
-      let :params do
-        {
-          manage_package_repo: false
-        }
-      end
-
-      it '::nodejs::repo::nodesource should not be in the catalog' do
-        is_expected.not_to contain_class('::nodejs::repo::nodesource')
-      end
-    end
-
-    # nodejs_debug_package_ensure
-    context 'with nodejs_debug_package_ensure set to present' do
-      let :params do
-        {
-          nodejs_debug_package_ensure: 'present'
-        }
-      end
-
-      it 'the nodejs package with debugging symbols should be installed' do
-        is_expected.to contain_package('nodejs-debuginfo').with('ensure' => 'present')
-      end
-    end
-
-    context 'with nodejs_debug_package_ensure set to absent' do
-      let :params do
-        {
-          nodejs_debug_package_ensure: 'absent'
-        }
-      end
-
-      it 'the nodejs package with debugging symbols should not be present' do
-        is_expected.to contain_package('nodejs-debuginfo').with('ensure' => 'absent')
-      end
-    end
-
-    # nodejs_dev_package_ensure
-    context 'with nodejs_dev_package_ensure set to present' do
-      let :params do
-        {
-          nodejs_dev_package_ensure: 'present'
-        }
-      end
-
-      it 'the nodejs development package should be installed' do
-        is_expected.to contain_package('nodejs-devel').with('ensure' => 'present')
-      end
-    end
-
-    context 'with nodejs_dev_package_ensure set to absent' do
-      let :params do
-        {
-          nodejs_dev_package_ensure: 'absent'
-        }
-      end
-
-      it 'the nodejs development package should not be present' do
-        is_expected.to contain_package('nodejs-devel').with('ensure' => 'absent')
-      end
-    end
-
-    # nodejs_package_ensure
-    context 'with nodejs_package_ensure set to present' do
-      let :params do
-        {
-          nodejs_package_ensure: 'present'
-        }
-      end
-
-      it 'the nodejs package should be present' do
-        is_expected.to contain_package('nodejs').with('ensure' => 'present')
-      end
-    end
-
-    context 'with nodejs_package_ensure set to absent' do
-      let :params do
-        {
-          nodejs_package_ensure: 'absent'
-        }
-      end
-
-      it 'the nodejs package should be absent' do
-        is_expected.to contain_package('nodejs').with('ensure' => 'absent')
-      end
-    end
-
-    # npm_package_ensure
-    context 'with npm_package_ensure set to present' do
-      let :params do
-        {
-          npm_package_ensure: 'present'
-        }
-      end
-
-      it 'the npm package should be present' do
-        is_expected.to contain_package('npm').with('ensure' => 'present')
-      end
-    end
-
-    context 'with npm_package_ensure set to absent' do
-      let :params do
-        {
-          npm_package_ensure: 'absent'
-        }
-      end
-
-      it 'the npm package should be absent' do
-        is_expected.to contain_package('npm').with('ensure' => 'absent')
-      end
-    end
-  end
   context 'when running on Amazon Linux 2015.03' do
     let :facts do
       {
-        osfamily: 'RedHat',
-        operatingsystem: 'Amazon',
-        operatingsystemrelease: '2015.03'
+        'os' => {
+          'family' => 'RedHat',
+          'name' => 'Amazon',
+          'release' => {
+            'full'  => '2015.03',
+            'major' => '2015',
+            'minor' => '03'
+          }
+        }
       }
     end
 

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -403,8 +403,10 @@ describe 'nodejs::npm', type: :define do
     context 'when run on Darwin' do
       let :facts do
         {
-          operatingsystem: 'Darwin',
-          osfamily: 'Darwin'
+          'os' => {
+            'family' => 'Darwin',
+            'name' => 'Darwin'
+          }
         }
       end
 
@@ -433,8 +435,13 @@ describe 'nodejs::npm', type: :define do
     context 'when run on Windows' do
       let :facts do
         {
-          operatingsystem: 'Windows',
-          osfamily: 'Windows'
+          'os' => {
+            'family' => 'Windows',
+            'name' => 'Windows',
+            'windows' => {
+              'system32' => 'C:\Windows\system32'
+            }
+          }
         }
       end
 


### PR DESCRIPTION
- Update the `repo_url_suffix` table in the README, dropping EOL
operating systems and adding new ones
- Drop explicit handling of Debian 6 and 7 (EOL)
- Drop explicit handling of Ubuntu 10.04 and 12.04 (EOL)
- Drop explicit handling of EOL Fedora versions
- Drop explicit handling of RHEL5 (EOL)
- Add explicit handling of Debian 9
- Replace most Legacy facts with Modern facts using the new facts hash
syntax. This explicitly drops support for Facter versions less than 3,
which are not supported under Puppet4/5 anyway.
- Drop explicit support for Amazon Linux versions less than 2015.03.
Amazon Linux is rolling distribution, and earlier versions did not have
Facter 3
- Use the Modern system32 fact

Also:
- Remove the old Puppetlabs footer from the README Reference CONTRIBUTING.md instead
- Perform minor doc fixes
- Use less granular error handling