### PR TITLE
Remove epel from fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,5 @@ fixtures:
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
     "portage": "git://github.com/gentoo/puppet-portage.git"
     "chocolatey": "git://github.com/chocolatey/puppet-chocolatey.git"
-    "epel": "git://github.com/stahnma/puppet-module-epel.git"
   symlinks:
     "nodejs": "#{source_dir}"


### PR DESCRIPTION
rspec-puppet tests do not explicitly need it given RHEL5 support has been removed.
