### PR TITLE
Remove legacy_debian_symlinks parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,16 +362,6 @@ applied before the local installation of npm packages using `nodejs::npm`.
 Path to cmd.exe on Windows. Defaults to C:\Windows\system32\cmd.exe. You may
 need to change this parameter for certain versions of Windows Server.
 
-#### `legacy_debian_symlinks`
-
-As per a Debian Technical Committee resolution (CTTE #614907), newer
-native packages on Debian/Ubuntu changed the path of the Node.js
-executable from /usr/bin/node to /usr/bin/nodejs. The nodejs-legacy package
-creates symlinks in the event that one is running applications that require
-the previous name. Setting this parameter to `true` recreates this behaviour.
-The Node.js package in the NodeSource repository already creates this symlink
-by default. This parameter defaults to `false`.
-
 #### `manage_package_repo`
 
 Whether to manage an external repository and use it as the source of the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 # == Class: nodejs: See README.md for documentation.
 class nodejs(
   $cmd_exe_path                                        = $nodejs::params::cmd_exe_path,
-  Boolean $legacy_debian_symlinks                      = $nodejs::params::legacy_debian_symlinks,
   Boolean $manage_package_repo                         = $nodejs::params::manage_package_repo,
   $nodejs_debug_package_ensure                         = $nodejs::params::nodejs_debug_package_ensure,
   Optional[String] $nodejs_debug_package_name          = $nodejs::params::nodejs_debug_package_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,18 +40,6 @@ class nodejs::install {
     }
   }
 
-  # Replicates the nodejs-legacy package functionality
-  if ($facts['os']['family'] == 'Debian' and $nodejs::legacy_debian_symlinks) {
-    file { '/usr/bin/node':
-      ensure => 'link',
-      target => '/usr/bin/nodejs',
-    }
-    file { '/usr/share/man/man1/node.1.gz':
-      ensure => 'link',
-      target => '/usr/share/man/man1/nodejs.1.gz',
-    }
-  }
-
   # npm
   if $nodejs::npm_package_name and $nodejs::npm_package_name != false {
     package { $nodejs::npm_package_name:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,6 @@ class nodejs::params {
   case $facts['os']['family'] {
     'Debian': {
       if $facts['os']['release']['major'] =~ /^[89]$/ {
-        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = undef
@@ -33,7 +32,6 @@ class nodejs::params {
         $repo_class                = '::nodejs::repo::nodesource'
       }
       elsif $facts['os']['release']['full'] =~ /^1[46]\.04$/ {
-        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
@@ -46,7 +44,6 @@ class nodejs::params {
       }
       else {
         warning("The ${module_name} module might not work on ${facts['os']['name']} ${facts['os']['release']['full']}. Sensible defaults will be attempted.")
-        $legacy_debian_symlinks    = false
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
         $nodejs_dev_package_name   = 'nodejs-dev'
@@ -59,8 +56,6 @@ class nodejs::params {
       }
     }
     'RedHat': {
-      $legacy_debian_symlinks      = false
-
       if $facts['os']['release']['major'] =~ /^[67]$/ {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-debuginfo'
@@ -99,7 +94,6 @@ class nodejs::params {
       }
     }
     'Suse': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = 'nodejs-debuginfo'
       $nodejs_dev_package_name   = 'nodejs-devel'
@@ -111,7 +105,6 @@ class nodejs::params {
       $repo_class                = undef
     }
     'Archlinux': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -123,7 +116,6 @@ class nodejs::params {
       $repo_class                = undef
     }
     'FreeBSD': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = 'www/node-devel'
@@ -135,7 +127,6 @@ class nodejs::params {
       $repo_class                = undef
     }
     'OpenBSD': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -147,7 +138,6 @@ class nodejs::params {
       $repo_class                = undef
     }
     'Darwin': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = 'nodejs-devel'
@@ -160,7 +150,6 @@ class nodejs::params {
       Package { provider => 'macports' }
     }
     'Windows': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef
@@ -173,7 +162,6 @@ class nodejs::params {
       Package { provider => 'chocolatey' }
     }
     'Gentoo': {
-      $legacy_debian_symlinks    = false
       $manage_package_repo       = false
       $nodejs_debug_package_name = undef
       $nodejs_dev_package_name   = undef

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -45,37 +45,6 @@ describe 'nodejs', type: :class do
         it { is_expected.to contain_file('root_npmrc').with_content(%r{^http-proxy=http://localhost:8080/$}) }
       end
 
-      # legacy_debian_symlinks
-      context 'with legacy_debian_symlinks set to true' do
-        let :params do
-          {
-            legacy_debian_symlinks: true
-          }
-        end
-
-        it 'the file resource /usr/bin/node should be in the catalog' do
-          is_expected.to contain_file('/usr/bin/node')
-        end
-        it 'the file resource /usr/share/man/man1/node.1.gz should be in the catalog' do
-          is_expected.to contain_file('/usr/share/man/man1/node.1.gz')
-        end
-      end
-
-      context 'with legacy_debian_symlinks set to false' do
-        let :params do
-          {
-            legacy_debian_symlinks: false
-          }
-        end
-
-        it 'the file resource /usr/bin/node should not be in the catalog' do
-          is_expected.not_to contain_file('/usr/bin/node')
-        end
-        it 'the file resource /usr/share/man/man1/node.1.gz should not be in the catalog' do
-          is_expected.not_to contain_file('/usr/share/man/man1/node.1.gz')
-        end
-      end
-
       # manage_package_repo
       context 'with manage_package_repo set to true' do
         let :default_params do


### PR DESCRIPTION
The (default) NodeSource packages already create symlinks with
alternatives by invoking update-alternatives as part of postinst for the
deb package.

Remove this feature and therefore avoid circular symlinks.

Fixes #335 