### PR TITLE
Use puppetlabs-apt to handle apt-transport-https

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ The following platforms should also work, but have not been tested:
 
 This modules uses `puppetlabs-apt` for the management of the NodeSource
 repository. If using an operating system of the Debian-based family, you will
-need to ensure that `puppetlabs-apt` version 2.x or above is installed.
+need to ensure that `puppetlabs-apt` version 4.4.0 or above is installed.
 
 If using CentOS/RHEL 6/7 and you wish to install Node.js from EPEL rather
 than from the NodeSource repository, you will need to ensure `stahnma-epel` is

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -6,8 +6,6 @@ class nodejs::repo::nodesource::apt {
   $pin        = $nodejs::repo::nodesource::pin
   $url_suffix = $nodejs::repo::nodesource::url_suffix
 
-  ensure_packages(['apt-transport-https', 'ca-certificates'])
-
   include ::apt
 
   if ($ensure != 'absent') {
@@ -23,10 +21,6 @@ class nodejs::repo::nodesource::apt {
       pin      => $pin,
       release  => $::lsbdistcodename,
       repos    => 'main',
-      require  => [
-        Package['apt-transport-https'],
-        Package['ca-certificates'],
-      ],
     }
 
     Apt::Source['nodesource'] -> Package<| tag == 'nodesource_repo' |>

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,7 +7,7 @@ install_module
 install_module_dependencies
 
 # Additional modules for soft deps
-install_module_from_forge('puppetlabs-apt', '>= 4.1.0 < 5.0.0')
+install_module_from_forge('puppetlabs-apt', '>= 4.4.0 < 5.0.0')
 install_module_from_forge('stahnma-epel', '>= 1.2.0 < 2.0.0')
 install_module_from_forge('chocolatey-chocolatey', '>= 1.2.6 < 2.0.0')
 install_module_from_forge('gentoo-portage', '>= 2.0.1 < 3.0.0')


### PR DESCRIPTION
puppetlabs-apt 4.4.0 now handles installation of apt-transport-https for
a selection of Debian families: wheezy, jessie, stretch, trusty, xenial.

This change should also ensure that this module works on Debian 10, which
no longer has the apt-transport-https package.

Fixes #345 
