### PR TITLE
Add repo_release parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,17 @@ Password for the proxy used by the repository, if required.
 
 User for the proxy used by the repository, if required.
 
+#### `repo_release`
+
+Optional value to override the apt distribution release.  Defaults to `undef`
+which will autodetect the distribution. If a value is specified, this will
+change the NodeSource apt repository distribution.
+This is useful if the distribution name does not exist in the NodeSource
+repositories. For example, the Ubilinux distribution release name 'dolcetto'
+does not exist in NodeSource, but is a derivative of Debian 9 (Stretch).
+Setting this value to `stretch` allows NodeSource repository management to
+then work as expected on these systems.
+
 #### `repo_url_suffix`
 
 Defaults to ```0.10``` which means that the latest NodeSource 0.10.x release
@@ -528,6 +539,7 @@ The following platforms should also work, but have not been tested:
 * Gentoo
 * OpenBSD
 * OpenSuse/SLES
+* Ubilinux
 * Windows
 
 ### Module dependencies

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class nodejs(
   $repo_proxy                                          = $nodejs::params::repo_proxy,
   $repo_proxy_password                                 = $nodejs::params::repo_proxy_password,
   $repo_proxy_username                                 = $nodejs::params::repo_proxy_username,
+  Optional[String] $repo_release                       = $nodejs::params::repo_release,
   $repo_url_suffix                                     = $nodejs::params::repo_url_suffix,
   Array $use_flags                                     = $nodejs::params::use_flags,
   Optional[String] $package_provider                   = $nodejs::params::package_provider,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class nodejs::params {
   $repo_proxy                  = 'absent'
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
+  $repo_release                = undef
   $repo_url_suffix             = '0.10'
   $use_flags                   = ['npm', 'snapshot']
 

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -7,6 +7,7 @@ class nodejs::repo::nodesource {
   $proxy          = $nodejs::repo_proxy
   $proxy_password = $nodejs::repo_proxy_password
   $proxy_username = $nodejs::repo_proxy_username
+  $release        = $nodejs::repo_release
   $url_suffix     = $nodejs::repo_url_suffix
 
   case $facts['os']['family'] {

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -4,6 +4,7 @@ class nodejs::repo::nodesource::apt {
   $enable_src = $nodejs::repo::nodesource::enable_src
   $ensure     = $nodejs::repo::nodesource::ensure
   $pin        = $nodejs::repo::nodesource::pin
+  $release    = $nodejs::repo::nodesource::release
   $url_suffix = $nodejs::repo::nodesource::url_suffix
 
   include ::apt
@@ -19,7 +20,7 @@ class nodejs::repo::nodesource::apt {
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
-      release  => $::lsbdistcodename,
+      release  => $release,
       repos    => 'main',
     }
 

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -97,6 +97,16 @@ describe 'nodejs', type: :class do
           end
         end
 
+        context 'and repo_release set to stretch' do
+          let :params do
+            default_params.merge!(repo_release: 'stretch')
+          end
+
+          it 'the repo apt::source resource should contain release = stretch' do
+            is_expected.to contain_apt__source('nodesource').with('release' => 'stretch')
+          end
+        end
+
         context 'and repo_pin not set' do
           let :params do
             default_params.merge!(repo_pin: :undef)


### PR DESCRIPTION
Some Debian-derived distributions use their own lsbdistcodename, but work fine when using Debian packages. Add a repo_release parameter to allow users to specify an apt::source release value which matches their Debian family and therefore allow management of the NodeSource repository on those systems.

Supersedes #342 