### PR TITLE
Set default version to 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,18 @@ To install Node.js and npm (using the NodeSource repository if possible):
 class { 'nodejs': }
 ```
 
-If you wish to install a Node.js 0.12.x release from the NodeSource repository
-rather than 0.10.x on Debian/RH platforms:
+The default version installed is currently `8.x`.
+
+If you wish to install a Node.js 9.x release from the NodeSource repository
+rather than 8.x on Debian/RHEL platforms:
 
 ```puppet
 class { 'nodejs':
-  repo_url_suffix => '0.12',
+  repo_url_suffix => '9.x',
 }
 ```
 
-Or if you wish to install a Node.js 5.x release from the NodeSource repository:
-(4.x. is left as a exercise for the reader)
-
-```puppet
-class { 'nodejs':
-  repo_url_suffix => '5.x',
-}
-```
+See the `repo_url_suffix` parameter entry below for possible values.
 
 ## Usage
 
@@ -486,11 +481,11 @@ then work as expected on these systems.
 
 #### `repo_url_suffix`
 
-Defaults to ```0.10``` which means that the latest NodeSource 0.10.x release
-is installed. If you wish to install a 0.12.x release or greater, you will
+Defaults to ```8.x``` which means that the latest NodeSource 8.x release
+is installed. If you wish to install a 9.x release or greater, you will
 need to set this value accordingly. This parameter is a just a reflection of
 the NodeSource URL structure - NodeSource might remove old versions (such as
-0.10 and 0.12) or add new ones (such as 8.x) at any time.
+0.10 and 0.12) or add new ones (such as 20.x) at any time.
 
 The following are ``repo_url_suffix`` values that reflect NodeSource versions
 that were available on 2017-11-29:
@@ -502,7 +497,6 @@ that were available on 2017-11-29:
 * Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x``` ```8.x```
 * Ubuntu 17.10 (Artful) ```4.x``` ```6.x``` ```8.x``` ```9.x```
-* RHEL/CentOS 5 ```0.10``` ```0.12```
 * RHEL/CentOS 6 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * RHEL/CentOS 7 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Amazon Linux - See RHEL/CentOS 7

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class nodejs::params {
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
   $repo_release                = undef
-  $repo_url_suffix             = '0.10'
+  $repo_url_suffix             = '8.x'
   $use_flags                   = ['npm', 'snapshot']
 
   $cmd_exe_path = $facts['os']['family'] ? {

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -117,13 +117,13 @@ describe 'nodejs', type: :class do
           end
         end
 
-        context 'and repo_url_suffix set to 0.12' do
+        context 'and repo_url_suffix set to 9.x' do
           let :params do
-            default_params.merge!(repo_url_suffix: '0.12')
+            default_params.merge!(repo_url_suffix: '9.x')
           end
 
-          it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_0.12' do
-            is_expected.to contain_apt__source('nodesource').with('location' => 'https://deb.nodesource.com/node_0.12')
+          it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_9.x' do
+            is_expected.to contain_apt__source('nodesource').with('location' => 'https://deb.nodesource.com/node_9.x')
           end
         end
 
@@ -310,15 +310,15 @@ describe 'nodejs', type: :class do
     if operatingsystemrelease =~ %r{^[6-7]\.(\d+)}
       operatingsystem     = 'CentOS'
       dist_type           = 'el'
-      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
-      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/SRPMS"
+      repo_baseurl        = "https://rpm.nodesource.com/pub_8.x/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
+      repo_source_baseurl = "https://rpm.nodesource.com/pub_8.x/#{dist_type}/#{operatingsystemmajrelease}/SRPMS"
       repo_descr          = "Node.js Packages for Enterprise Linux #{operatingsystemmajrelease} - \$basearch"
       repo_source_descr   = "Node.js for Enterprise Linux #{operatingsystemmajrelease} - \$basearch - Source"
     else
       operatingsystem     = 'Fedora'
       dist_type           = 'fc'
-      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
-      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/SRPMS"
+      repo_baseurl        = "https://rpm.nodesource.com/pub_8.x/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
+      repo_source_baseurl = "https://rpm.nodesource.com/pub_8.x/#{dist_type}/#{operatingsystemmajrelease}/SRPMS"
       repo_descr          = "Node.js Packages for Fedora Core #{operatingsystemmajrelease} - \$basearch"
       repo_source_descr   = "Node.js for Fedora Core #{operatingsystemmajrelease} - \$basearch - Source"
     end
@@ -1120,8 +1120,8 @@ describe 'nodejs', type: :class do
       }
     end
 
-    repo_baseurl        = 'https://rpm.nodesource.com/pub_0.10/el/7/$basearch'
-    repo_source_baseurl = 'https://rpm.nodesource.com/pub_0.10/el/7/SRPMS'
+    repo_baseurl        = 'https://rpm.nodesource.com/pub_8.x/el/7/$basearch'
+    repo_source_baseurl = 'https://rpm.nodesource.com/pub_8.x/el/7/SRPMS'
     repo_descr          = 'Node.js Packages for Enterprise Linux 7 - $basearch'
     repo_source_descr   = 'Node.js for Enterprise Linux 7 - $basearch - Source'
 


### PR DESCRIPTION
Node.js version 8.x is the current LTS version.

- Also remove references to RHEL5 since support has been dropped
- Also change some unit tests to reflect current versions and actual
  use cases

Fixes #356 