### PR TITLE
Fix default install as non-root user, #305

### DIFF
--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -8,7 +8,7 @@ define nodejs::npm (
   String $package           = $title,
   $source                   = 'registry',
   Array $uninstall_options  = [],
-  String $home_dir          = "",
+  $home_dir                 = undef,
   $user                     = undef,
   Boolean $use_package_json = false,
 ) {

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -8,7 +8,7 @@ define nodejs::npm (
   String $package           = $title,
   $source                   = 'registry',
   Array $uninstall_options  = [],
-  $home_dir                 = '/root',
+  String $home_dir          = "",
   $user                     = undef,
   Boolean $use_package_json = false,
 ) {
@@ -74,13 +74,19 @@ define nodejs::npm (
     Nodejs::Npm::Global_config_entry<| title == 'https-proxy' |> -> Exec["npm_install_${name}"]
     Nodejs::Npm::Global_config_entry<| title == 'proxy' |> -> Exec["npm_install_${name}"]
 
+    if !empty($home_dir) {
+      $_homedir = "HOME=${home_dir}"
+    } else {
+      $_homedir = undef
+    }
+
     if $use_package_json {
       exec { "npm_${npm_command}_${name}":
         command     => "${npm_path} ${npm_command} ${options}",
         unless      => $list_command,
         user        => $user,
         cwd         => $target,
-        environment => "HOME=${home_dir}",
+        environment => $_homedir,
         require     => Class['nodejs'],
       }
     } else {
@@ -89,7 +95,7 @@ define nodejs::npm (
         unless      => $install_check,
         user        => $user,
         cwd         => $target,
-        environment => "HOME=${home_dir}",
+        environment => $_homedir,
         require     => Class['nodejs'],
       }
     }

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -52,10 +52,6 @@ describe 'nodejs::npm', type: :define do
         it 'the exec directory should be /home/npm/packages' do
           is_expected.to contain_exec('npm_install_express').with('cwd' => '/home/npm/packages')
         end
-
-        it 'the environment variable HOME should be /root' do
-          is_expected.to contain_exec('npm_install_express').with('environment' => 'HOME=/root')
-        end
       end
 
       # npm install <package> <install_options>


### PR DESCRIPTION
npm.pp currently sets /root as the environment HOMEDIR.  This breaks using nodejs::npm as a non-root user, as per #305.  nodejs::npm::home_dir parameter can be set to override this, but is not intuitive, documented or automatic.

Instead, unset $home_dir parameter by default  and only use it to set HOMEDIR environment variable if populated.  If not set, npm will use the default home directory for the specified user.