### PR TITLE
fix 'nodejs::repo_ensure: absent' for yum

### DIFF
--- a/manifests/repo/nodesource/yum.pp
+++ b/manifests/repo/nodesource/yum.pp
@@ -58,11 +58,11 @@ class nodejs::repo::nodesource::yum {
   else {
 
     yumrepo { 'nodesource':
-      enabled => 'absent',
+      ensure => 'absent',
     }
 
     yumrepo { 'nodesource-source':
-      enabled => 'absent',
+      ensure => 'absent',
     }
   }
 }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -434,8 +434,8 @@ describe 'nodejs', type: :class do
           end
 
           it 'the nodesource yum repo files should not exist' do
-            is_expected.to contain_yumrepo('nodesource').with('enabled' => 'absent')
-            is_expected.to contain_yumrepo('nodesource-source').with('enabled' => 'absent')
+            is_expected.to contain_yumrepo('nodesource').with('ensure' => 'absent')
+            is_expected.to contain_yumrepo('nodesource-source').with('ensure' => 'absent')
           end
         end
 
@@ -1192,8 +1192,8 @@ describe 'nodejs', type: :class do
         end
 
         it 'the nodesource yum repo files should not exist' do
-          is_expected.to contain_yumrepo('nodesource').with('enabled' => 'absent')
-          is_expected.to contain_yumrepo('nodesource-source').with('enabled' => 'absent')
+          is_expected.to contain_yumrepo('nodesource').with('ensure' => 'absent')
+          is_expected.to contain_yumrepo('nodesource-source').with('ensure' => 'absent')
         end
       end
 


### PR DESCRIPTION
Presently, setting ensure to 'absent' results in creating two files in
/etc/yum.repos.d:

$ cat nodesource.repo
[nodesource]
$ cat nodesource-source.repo
[nodesource-source]

This results in yum failure:
$ sudo yum check-update
Loaded plugins: fastestmirror, security
Repository 'nodesource-source' is missing name in configuration, using id
Repository 'nodesource' is missing name in configuration, using id
Loading mirror speeds from cached hostfile
Error: Cannot find a valid baseurl for repo: nodesource

It is better to ensure these files do not exist. The corresponding apt
class is already set up this way.

Note: I was unable to get local tests working for this module. Please
test before merging.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
