### PR TITLE
Ensure NPM secret keys are idempotent in global_config_entry

### DIFF
--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -11,17 +11,39 @@ define nodejs::npm::global_config_entry (
 
   case $ensure {
     'absent': {
-      $command        = "config delete ${config_setting} --global"
-      $onlyif_command = $::osfamily ? {
-        'Windows' => "${cmd_exe_path} /C ${npm_path} get --global| FINDSTR /B \"${config_setting}\"",
-        default   => "${npm_path} get --global | /bin/grep -e \"^${config_setting}\"",
+      $command = "config delete ${config_setting} --global"
+
+      # If this is a secret key, determine if it is set properly outside of NPM
+      # https://github.com/voxpupuli/puppet-nodejs/issues/326
+      if $config_setting =~ /(_|:_)/ {
+        $onlyif_command = $::osfamily ? {
+          'Windows' => "${cmd_exe_path} /C FOR /F %G IN ('${npm_path} config get globalconfig') DO IF EXIST %G (FINDSTR /B /C:\"${$config_setting}\" %G) ELSE (EXIT 1)",
+          default   => "test -f $(${npm_path} config get globalconfig) && /bin/grep -qe \"^${$config_setting}\" $(${npm_path} config get globalconfig)",
+        }
+      }
+      else {
+        $onlyif_command = $::osfamily ? {
+          'Windows' => "${cmd_exe_path} /C ${npm_path} get --global| FINDSTR /B \"${config_setting}\"",
+          default   => "${npm_path} get --global | /bin/grep -e \"^${config_setting}\"",
+        }
       }
     }
     default: {
-      $command        = "config set ${config_setting} ${value} --global"
-      $onlyif_command = $::osfamily ? {
-        'Windows' => "${cmd_exe_path} /C FOR /F %i IN ('${npm_path} get ${config_setting} --global') DO IF \"%i\" NEQ \"${value}\" ( EXIT 0 ) ELSE ( EXIT 1 )",
-        default   => "/usr/bin/test \"$(${npm_path} get ${config_setting} --global | /usr/bin/tr -d '\n')\" != \"${value}\"",
+      $command = "config set ${config_setting} ${value} --global"
+
+      # If this is a secret key, determine if it is set properly outside of NPM
+      # https://github.com/voxpupuli/puppet-nodejs/issues/326
+      if $config_setting =~ /(_|:_)/ {
+        $onlyif_command = $::osfamily ? {
+          'Windows' => "${cmd_exe_path} /V /C FOR /F %G IN ('${npm_path} config get globalconfig') DO IF EXIST %G (FINDSTR /B /C:\"${$config_setting}=\\\"${$value}\\\"\" %G & IF !ERRORLEVEL! EQU 0 ( EXIT 1 ) ELSE ( EXIT 0 )) ELSE ( EXIT 0 )",
+          default   => "! test -f $(${npm_path} config get globalconfig) || ! /bin/grep -qe '^${$config_setting}=\"${$value}\"' $(${npm_path} config get globalconfig)",
+        }
+      }
+      else {
+        $onlyif_command = $::osfamily ? {
+          'Windows' => "${cmd_exe_path} /C FOR /F %i IN ('${npm_path} get ${config_setting} --global') DO IF \"%i\" NEQ \"${value}\" ( EXIT 0 ) ELSE ( EXIT 1 )",
+          default   => "/usr/bin/test \"$(${npm_path} get ${config_setting} --global | /usr/bin/tr -d '\n')\" != \"${value}\"",
+        }
       }
     }
   }

--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -16,13 +16,13 @@ define nodejs::npm::global_config_entry (
       # If this is a secret key, determine if it is set properly outside of NPM
       # https://github.com/voxpupuli/puppet-nodejs/issues/326
       if $config_setting =~ /(_|:_)/ {
-        $onlyif_command = $::osfamily ? {
+        $onlyif_command = $facts['os']['family'] ? {
           'Windows' => "${cmd_exe_path} /C FOR /F %G IN ('${npm_path} config get globalconfig') DO IF EXIST %G (FINDSTR /B /C:\"${$config_setting}\" %G) ELSE (EXIT 1)",
           default   => "test -f $(${npm_path} config get globalconfig) && /bin/grep -qe \"^${$config_setting}\" $(${npm_path} config get globalconfig)",
         }
       }
       else {
-        $onlyif_command = $::osfamily ? {
+        $onlyif_command = $facts['os']['family'] ? {
           'Windows' => "${cmd_exe_path} /C ${npm_path} get --global| FINDSTR /B \"${config_setting}\"",
           default   => "${npm_path} get --global | /bin/grep -e \"^${config_setting}\"",
         }
@@ -34,13 +34,13 @@ define nodejs::npm::global_config_entry (
       # If this is a secret key, determine if it is set properly outside of NPM
       # https://github.com/voxpupuli/puppet-nodejs/issues/326
       if $config_setting =~ /(_|:_)/ {
-        $onlyif_command = $::osfamily ? {
+        $onlyif_command = $facts['os']['family'] ? {
           'Windows' => "${cmd_exe_path} /V /C FOR /F %G IN ('${npm_path} config get globalconfig') DO IF EXIST %G (FINDSTR /B /C:\"${$config_setting}=\\\"${$value}\\\"\" %G & IF !ERRORLEVEL! EQU 0 ( EXIT 1 ) ELSE ( EXIT 0 )) ELSE ( EXIT 0 )",
           default   => "! test -f $(${npm_path} config get globalconfig) || ! /bin/grep -qe '^${$config_setting}=\"${$value}\"' $(${npm_path} config get globalconfig)",
         }
       }
       else {
-        $onlyif_command = $::osfamily ? {
+        $onlyif_command = $facts['os']['family'] ? {
           'Windows' => "${cmd_exe_path} /C FOR /F %i IN ('${npm_path} get ${config_setting} --global') DO IF \"%i\" NEQ \"${value}\" ( EXIT 0 ) ELSE ( EXIT 1 )",
           default   => "/usr/bin/test \"$(${npm_path} get ${config_setting} --global | /usr/bin/tr -d '\n')\" != \"${value}\"",
         }
@@ -55,7 +55,7 @@ define nodejs::npm::global_config_entry (
   }
 
   #Determine exec provider
-  $provider = $::osfamily ? {
+  $provider = $facts['os']['family'] ? {
     'Windows' => 'windows',
     default   => 'shell',
   }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -37,5 +37,22 @@ describe 'nodejs class:', unless: UNSUPPORTED_PLATFORMS.include?(fact('os.family
         expect(pkg_output.stdout).to match 'epel'
       end
     end
+
+    context 'set global_config_entry secret', if: fact('os.family') == 'RedHat' do
+      let (:pp) { "class { 'nodejs': }; nodejs::npm::global_config_entry { '//path.to.registry/:_secret': ensure => present, value => 'cGFzc3dvcmQ=', require => Package[nodejs],}" }
+
+      it_behaves_like 'an idempotent resource'
+
+      describe package('nodejs') do
+        it { is_expected.to be_installed }
+      end
+
+      describe 'npm config' do
+        it ('contains the global_config_entry secret') do
+          npm_output = shell("cat $(/usr/bin/npm config get globalconfig)")
+          expect(npm_output.stdout).to match '//path.to.registry/:_secret="cGFzc3dvcmQ="'
+        end
+      end
+    end
   end
 end

--- a/spec/defines/global_config_entry_spec.rb
+++ b/spec/defines/global_config_entry_spec.rb
@@ -49,6 +49,20 @@ describe 'nodejs::npm::global_config_entry', type: :define do
           is_expected.to contain_exec('npm_config absent color').with('command' => '/usr/bin/npm config delete color --global')
         end
       end
+
+      context 'with name set to :_secret and ensure set to present' do
+        let(:title) { '//path.to.registry/:_secret' }
+        let :params do
+          {
+            value: 'cGFzc3dvcmQ=',
+            ensure: 'present'
+          }
+        end
+
+        it 'npm config set :_secret should be executed' do
+          is_expected.to contain_exec('npm_config present :_secret').with('command' => '/usr/bin/npm config set //path.to.registry/:_secret cGFzc3dvcmQ= --global')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
- Ensure NPM secret keys are idempotent in global_config_entry by matching key/value using npm's regex for secrets (https://github.com/npm/cli/blob/4c65cd952bc8627811735bea76b9b110cc4fc80e/lib/config.js#L179). If a secret is being set, dynamically determine the path to the global config file and match the key and value in the file (outside of npm itself)
- New test(s)

#### This Pull Request (PR) fixes the following issues
Fixes #326 
