### PR TITLE
Fix idempotence of unquoted secrets

### DIFF
--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -36,7 +36,7 @@ define nodejs::npm::global_config_entry (
       if $config_setting =~ /(_|:_)/ {
         $onlyif_command = $facts['os']['family'] ? {
           'Windows' => "${cmd_exe_path} /V /C FOR /F %G IN ('${npm_path} config get globalconfig') DO IF EXIST %G (FINDSTR /B /C:\"${$config_setting}=\\\"${$value}\\\"\" %G & IF !ERRORLEVEL! EQU 0 ( EXIT 1 ) ELSE ( EXIT 0 )) ELSE ( EXIT 0 )",
-          default   => "! test -f $(${npm_path} config get globalconfig) || ! /bin/grep -qe '^${$config_setting}=\"\?${$value}\"\?$' $(${npm_path} config get globalconfig)",
+          default   => "! test -f $(${npm_path} config get globalconfig) || ! /bin/grep -qe '^${$config_setting}=\"\\?${$value}\"\\?$' $(${npm_path} config get globalconfig)",
         }
       }
       else {

--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -36,7 +36,7 @@ define nodejs::npm::global_config_entry (
       if $config_setting =~ /(_|:_)/ {
         $onlyif_command = $facts['os']['family'] ? {
           'Windows' => "${cmd_exe_path} /V /C FOR /F %G IN ('${npm_path} config get globalconfig') DO IF EXIST %G (FINDSTR /B /C:\"${$config_setting}=\\\"${$value}\\\"\" %G & IF !ERRORLEVEL! EQU 0 ( EXIT 1 ) ELSE ( EXIT 0 )) ELSE ( EXIT 0 )",
-          default   => "! test -f $(${npm_path} config get globalconfig) || ! /bin/grep -qe '^${$config_setting}=\"${$value}\"' $(${npm_path} config get globalconfig)",
+          default   => "! test -f $(${npm_path} config get globalconfig) || ! /bin/grep -qe '^${$config_setting}=\"\?${$value}\"\?$' $(${npm_path} config get globalconfig)",
         }
       }
       else {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The fix in https://github.com/voxpupuli/puppet-nodejs/pull/386 fixes idempotence for secrets that contain characters (like '=') that cause NPM to quote them in npmrc. Secrets that end up unquoted in npmrc are not handled correctly however. This fix makes the quotes optional when checking if the config value is already set correctly.

#### This Pull Request (PR) fixes the following issues
n/a