### PR TITLE
Fix global_config_entry dependency on NPM when using nodesource repo

### DIFF
--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -50,6 +50,8 @@ define nodejs::npm::global_config_entry (
 
   if $nodejs::npm_package_ensure != 'absent' {
     $exec_require = "Package[${nodejs::npm_package_name}]"
+  } elsif $nodejs::repo_class == '::nodejs::repo::nodesource' {
+    $exec_require = "Package[${nodejs::nodejs_package_name}]"
   } else {
     $exec_require = undef
   }

--- a/spec/defines/global_config_entry_spec.rb
+++ b/spec/defines/global_config_entry_spec.rb
@@ -63,6 +63,86 @@ describe 'nodejs::npm::global_config_entry', type: :define do
           is_expected.to contain_exec('npm_config present //path.to.registry/:_secret').with('command' => '/usr/bin/npm config set //path.to.registry/:_secret cGFzc3dvcmQ= --global')
         end
       end
+
+      context 'with ensure npm package set to present' do
+        let(:pre_condition) do
+          <<-PUPPET
+            class { 'nodejs':
+              nodejs_package_name => 'node-package-name',
+              npm_package_name    => 'npm-package-name',
+              npm_package_ensure  => present,
+            }
+          PUPPET
+        end
+        let(:title) { 'prefer-online' }
+        let :params do
+          {
+            value: 'true'
+          }
+        end
+
+        it 'npm config set prefer-online should be executed and require npm package' do
+          is_expected.to contain_exec('npm_config present prefer-online').with('command' => '/usr/bin/npm config set prefer-online true --global').that_requires('Package[npm-package-name]')
+        end
+
+        it 'npm config set prefer-online should not require node package' do
+          is_expected.not_to contain_exec('npm_config present prefer-online').with('command' => '/usr/bin/npm config set prefer-online true --global').that_requires('Package[node-package-name]')
+        end
+      end
+
+      context 'with ensure npm package set to absent and repo class set to nodesource' do
+        let(:pre_condition) do
+          <<-PUPPET
+            class { 'nodejs':
+              nodejs_package_name => 'node-package-name',
+              npm_package_ensure  => absent,
+              repo_class          => '::nodejs::repo::nodesource',
+            }
+          PUPPET
+        end
+        let(:title) { 'loglevel' }
+        let :params do
+          {
+            value: 'debug'
+          }
+        end
+
+        it 'npm config set loglevel should be executed and require nodejs package' do
+          is_expected.to contain_exec('npm_config present loglevel').with('command' => '/usr/bin/npm config set loglevel debug --global').that_requires('Package[node-package-name]')
+        end
+      end
+
+      context 'with ensure npm package set to absent and repo class set to something else' do
+        let(:pre_condition) do
+          <<-PUPPET
+            class something_else { }
+            class { 'nodejs':
+              nodejs_package_name => 'node-package-name',
+              npm_package_name    => 'npm-package-name',
+              npm_package_ensure  => absent,
+              repo_class          => '::something_else',
+            }
+          PUPPET
+        end
+        let(:title) { 'init-version' }
+        let :params do
+          {
+            value: '0.0.1'
+          }
+        end
+
+        it 'npm config set init-version should be executed' do
+          is_expected.to contain_exec('npm_config present init-version').with('command' => '/usr/bin/npm config set init-version 0.0.1 --global')
+        end
+
+        it 'npm config set init-version should not require npm package' do
+          is_expected.not_to contain_exec('npm_config present init-version').with('command' => '/usr/bin/npm config set init-version 0.0.1 --global').that_requires('Package[npm-package-name]')
+        end
+
+        it 'npm config set init-version should not require node package' do
+          is_expected.not_to contain_exec('npm_config present init-version').with('command' => '/usr/bin/npm config set init-version 0.0.1 --global').that_requires('Package[node-package-name]')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
This fixes the npm_config exec in the global_config_entry class not having a dependency on the package that installs NPM when using the nodesource class.

#### This Pull Request (PR) fixes the following issues
#404 