### PR TITLE
Fix nodejs dev package name for Ubuntu 20.04 . #421

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -4,6 +4,7 @@
   docker_sets:
     - set: ubuntu1604-64
     - set: ubuntu1804-64
+    - set: ubuntu2004-64
     - set: centos7-64
     - set: centos8-64
     - set: debian8-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu2004-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ This module has received limited testing on:
 
 * CentOS/RHEL 6/7/8
 * Debian 8
-* Ubuntu 16.04/18.04
+* Ubuntu 16.04/18.04/20.04
 
 The following platforms should also work, but have not been tested:
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,17 @@ class nodejs::params {
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
       }
+      elsif $facts['os']['release']['full'] =~ /^20\.04$/ {
+        $manage_package_repo       = true
+        $nodejs_debug_package_name = 'nodejs-dbg'
+        $nodejs_dev_package_name   = 'libnode-dev'
+        $nodejs_dev_package_ensure = 'absent'
+        $nodejs_package_name       = 'nodejs'
+        $npm_package_ensure        = 'absent'
+        $npm_package_name          = 'npm'
+        $npm_path                  = '/usr/bin/npm'
+        $repo_class                = '::nodejs::repo::nodesource'
+      }
       else {
         warning("The ${module_name} module might not work on ${facts['os']['name']} ${facts['os']['release']['full']}. Sensible defaults will be attempted.")
         $manage_package_repo       = true

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     }
   ],

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -15,6 +15,12 @@ describe 'nodejs', type: :class do
                                       false
                                     end
 
+      native_debian_devel_package = if facts[:os]['name'] == 'Ubuntu' && facts[:os]['release']['major'] == '20.04'
+                                      'libnode-dev'
+                                    else
+                                      'nodejs-dev'
+                                    end
+
       it 'the file resource root_npmrc should be in the catalog' do
         is_expected.to contain_file('root_npmrc').with(
           'ensure' => 'file',
@@ -196,11 +202,11 @@ describe 'nodejs', type: :class do
         if is_supported_debian_version
 
           it 'the nodejs development package resource should not be present' do
-            is_expected.not_to contain_package('nodejs-dev')
+            is_expected.not_to contain_package(native_debian_devel_package)
           end
         else
           it 'the nodejs development package should be installed' do
-            is_expected.to contain_package('nodejs-dev').with('ensure' => 'present')
+            is_expected.to contain_package(native_debian_devel_package).with('ensure' => 'present')
           end
         end
       end
@@ -215,11 +221,11 @@ describe 'nodejs', type: :class do
         if is_supported_debian_version
 
           it 'the nodejs development package resource should not be present' do
-            is_expected.not_to contain_package('nodejs-dev')
+            is_expected.not_to contain_package(native_debian_devel_package)
           end
         else
           it 'the nodejs development package should not be present' do
-            is_expected.to contain_package('nodejs-dev').with('ensure' => 'absent')
+            is_expected.to contain_package(native_debian_devel_package).with('ensure' => 'absent')
           end
         end
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

nodejs-dev package no longer exist for Ubuntu 20.04.
It has been replaced by libnode-dev .

#### This Pull Request (PR) fixes the following issues

Fixes #421 

