### PR TITLE
Drop duplicate class declaration

### DIFF
--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -46,11 +46,9 @@ class nodejs::repo::nodesource {
       $source_descr   = "Node.js for ${name_string} - \$basearch - Source"
       $source_baseurl = "https://rpm.nodesource.com/pub_${url_suffix}/${dist_type}/${dist_version}/SRPMS"
 
-      class { 'nodejs::repo::nodesource::yum': }
       contain 'nodejs::repo::nodesource::yum'
     }
     'Debian': {
-      class { 'nodejs::repo::nodesource::apt': }
       contain 'nodejs::repo::nodesource::apt'
     }
     default: {


### PR DESCRIPTION
The `contain` not only enforces the ordering, it also adds it to the
catalog. We don't need to call the class explicitly in advance.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
