### PR TITLE
Debian and Ubuntu versioning and package name fixes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,13 +22,21 @@ class nodejs::params {
   case $facts['os']['family'] {
     'Debian': {
       if $facts['os']['release']['major'] =~ /^(9|10)$/ {
+        $debian_nodejs_dev_package_name = $facts['os']['release']['major'] ? {
+          '9'     => 'nodejs-dev',
+          default => 'libnode-dev',
+        }
+        $debian_npm_package_name = $facts['os']['release']['major'] ? {
+          '9'     => false,
+          default => 'npm',
+        }
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-dbg'
-        $nodejs_dev_package_name   = undef
+        $nodejs_dev_package_name   = $debian_nodejs_dev_package_name
         $nodejs_dev_package_ensure = 'absent'
         $nodejs_package_name       = 'nodejs'
         $npm_package_ensure        = 'absent'
-        $npm_package_name          = false
+        $npm_package_name          = $debian_npm_package_name
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
       }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -6,9 +6,10 @@ describe 'nodejs class:' do
     pkg_cmd = 'yum info nodejs | grep "^From repo"'
     install_module_from_forge('puppet-epel', '>= 3.0.0 < 4.0.0')
   when 'Debian'
-    pkg_cmd = 'dpkg -s nodejs | grep ^Maintainer'
+    pkg_cmd = 'dpkg -s nodejs | grep "^Maintainer"'
     install_module_from_forge('puppetlabs-apt', '>= 4.4.0 < 8.0.0')
   end
+
   context 'default parameters' do
     let(:pp) { "class { 'nodejs': }" }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -79,3 +79,55 @@ describe 'nodejs class:' do
     end
   end
 end
+
+# Must uninstall the default nodesource repo and packages which come from there before attempting
+# to install native packages.
+context 'uninstall' do
+  let(:pp) do
+    "
+    class { 'nodejs':
+      nodejs_debug_package_ensure => absent,
+      nodejs_dev_package_ensure   => absent,
+      nodejs_package_ensure       => absent,
+      npm_package_ensure          => absent,
+      repo_ensure                 => absent,
+    }
+    "
+  end
+
+  it_behaves_like 'an idempotent resource'
+end
+
+context 'native Debian packages' do
+  let(:pp) do
+    "
+    class { 'nodejs':
+      manage_package_repo       => false,
+      nodejs_dev_package_ensure => present,
+      npm_package_ensure        => present,
+    }
+    "
+  end
+
+  it_behaves_like 'an idempotent resource'
+
+  if fact('os.family') == 'Debian'
+    if %w[9 16.04 18.04].include? fact('os.release.major')
+      describe package('nodejs-dev') do
+        it { is_expected.to be_installed }
+      end
+      if %w[16.04 18.04].include? fact('os.release.major')
+        describe package('npm') do
+          it { is_expected.to be_installed }
+        end
+      end
+    else
+      describe package('libnode-dev') do
+        it { is_expected.to be_installed }
+      end
+      describe package('npm') do
+        it { is_expected.to be_installed }
+      end
+    end
+  end
+end

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -9,13 +9,9 @@ describe 'nodejs', type: :class do
         facts
       end
 
-      is_supported_debian_version = if facts[:os]['family'] == 'Debian' && %w[9 10].include?(facts[:os]['release']['major'])
-                                      true
-                                    else
-                                      false
-                                    end
-
-      native_debian_devel_package = if facts[:os]['name'] == 'Ubuntu' && facts[:os]['release']['major'] == '20.04'
+      native_debian_devel_package = if facts[:os]['name'] == 'Ubuntu' && Gem::Version.new(facts[:os]['release']['major']) >= Gem::Version.new('20.04')
+                                      'libnode-dev'
+                                    elsif facts[:os]['name'] == 'Debian' && Gem::Version.new(facts[:os]['release']['major']) >= Gem::Version.new(10)
                                       'libnode-dev'
                                     else
                                       'nodejs-dev'
@@ -199,15 +195,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if is_supported_debian_version
-
-          it 'the nodejs development package resource should not be present' do
-            is_expected.not_to contain_package(native_debian_devel_package)
-          end
-        else
-          it 'the nodejs development package should be installed' do
-            is_expected.to contain_package(native_debian_devel_package).with('ensure' => 'present')
-          end
+        it 'the nodejs development package should be installed' do
+          is_expected.to contain_package(native_debian_devel_package).with('ensure' => 'present')
         end
       end
 
@@ -218,15 +207,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if is_supported_debian_version
-
-          it 'the nodejs development package resource should not be present' do
-            is_expected.not_to contain_package(native_debian_devel_package)
-          end
-        else
-          it 'the nodejs development package should not be present' do
-            is_expected.to contain_package(native_debian_devel_package).with('ensure' => 'absent')
-          end
+        it 'the nodejs development package should not be present' do
+          is_expected.to contain_package(native_debian_devel_package).with('ensure' => 'absent')
         end
       end
 
@@ -263,8 +245,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if is_supported_debian_version
-
+        # Debian 9 (stretch) doesn't have npm in the standard repositories (it has been backported though).
+        if facts[:os]['family'] == 'Debian' && facts[:os]['release']['major'] == '9'
           it 'the npm package resource should not be present' do
             is_expected.not_to contain_package('npm')
           end
@@ -282,8 +264,8 @@ describe 'nodejs', type: :class do
           }
         end
 
-        if is_supported_debian_version
-
+        # Debian 9 (stretch) doesn't have npm in the standard repositories (it has been backported though).
+        if facts[:os]['family'] == 'Debian' && facts[:os]['release']['major'] == '9'
           it 'the npm package resource should not be present' do
             is_expected.not_to contain_package('npm')
           end


### PR DESCRIPTION
* Debian has a native nodejs dev package, so define that.

* Debian 10 has a native npm package, so define that for Debian 10.

* Improve `native_debian_devel_package` logic: support Debian 10 onward and Ubuntu 20.04 onward with the libnode-dev package name.

* After the above changes, the variable `is_supported_debian_version` becomes obsolete, so most of the tests can work normally. The only special case is Debian 9 lacking the native npm package.