### PR TITLE
add parameter $manage_nodejs_package

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ applied before the local installation of npm packages using `nodejs::npm`.
 Path to cmd.exe on Windows. Defaults to C:\Windows\system32\cmd.exe. You may
 need to change this parameter for certain versions of Windows Server.
 
+#### `manage_nodejs_package`
+
+Whether to manage the nodejs and nodejs-dev packages. Defaults to `true`.
+
 #### `manage_package_repo`
 
 Whether to manage an external repository and use it as the source of the

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 # == Class: nodejs: See README.md for documentation.
 class nodejs (
   $cmd_exe_path                                        = $nodejs::params::cmd_exe_path,
+  Boolean $manage_nodejs_package                       = true,
   Boolean $manage_package_repo                         = $nodejs::params::manage_package_repo,
   $nodejs_debug_package_ensure                         = $nodejs::params::nodejs_debug_package_ensure,
   Optional[String] $nodejs_debug_package_name          = $nodejs::params::nodejs_debug_package_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,7 @@ class nodejs::install {
   }
 
   # npm is a Gentoo USE flag
-  if $facts['os']['name'] == 'Gentoo' {
+  if $facts['os']['name'] == 'Gentoo' and $nodejs::manage_nodejs_package {
     package_use { $nodejs::nodejs_package_name:
       ensure => present,
       target => 'nodejs-flags',
@@ -20,13 +20,15 @@ class nodejs::install {
   Package { provider => $nodejs::package_provider }
 
   # nodejs
-  package { $nodejs::nodejs_package_name:
-    ensure => $nodejs::nodejs_package_ensure,
-    tag    => 'nodesource_repo',
+  if $nodejs::manage_nodejs_package {
+    package { $nodejs::nodejs_package_name:
+      ensure => $nodejs::nodejs_package_ensure,
+      tag    => 'nodesource_repo',
+    }
   }
 
   # nodejs-development
-  if $nodejs::nodejs_dev_package_name {
+  if $nodejs::manage_nodejs_package and $nodejs::nodejs_dev_package_name {
     package { $nodejs::nodejs_dev_package_name:
       ensure => $nodejs::nodejs_dev_package_ensure,
       tag    => 'nodesource_repo',

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -59,6 +59,27 @@ describe 'nodejs', type: :class do
           }
         end
 
+        context 'and manage_nodejs_package set to true' do
+          let :params do
+            default_params.merge!(manage_nodejs_package: true)
+          end
+
+          it 'the nodejs package resource should be present' do
+            is_expected.to contain_package('nodejs')
+          end
+        end
+
+        context 'and manage_nodejs_package set to false' do
+          let :params do
+            default_params.merge!(manage_nodejs_package: false)
+          end
+
+          it 'the nodejs and dev package resources should not be present' do
+            is_expected.not_to contain_package('nodejs')
+            is_expected.not_to contain_package(native_debian_devel_package)
+          end
+        end
+
         context 'and repo_class set to ::nodejs::repo::nodesource' do
           let :params do
             default_params.merge!(repo_class: 'nodejs::repo::nodesource')
@@ -349,6 +370,27 @@ describe 'nodejs', type: :class do
           {
             manage_package_repo: true
           }
+        end
+
+        context 'and manage_nodejs_package set to true' do
+          let :params do
+            default_params.merge!(manage_nodejs_package: true)
+          end
+
+          it 'the nodejs package resource should be present' do
+            is_expected.to contain_package('nodejs')
+          end
+        end
+
+        context 'and manage_nodejs_package set to false' do
+          let :params do
+            default_params.merge!(manage_nodejs_package: false)
+          end
+
+          it 'the nodejs and dev package resources should not be present' do
+            is_expected.not_to contain_package('nodejs')
+            is_expected.not_to contain_package('nodejs-devel')
+          end
         end
 
         context 'and repo_class set to ::nodejs::repo::nodesource' do
@@ -686,6 +728,32 @@ describe 'nodejs', type: :class do
       end
     end
 
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('nodejs')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs and dev package resources should not be present' do
+        is_expected.not_to contain_package('nodejs')
+        is_expected.not_to contain_package('nodejs-devel')
+      end
+    end
+
     # nodejs_package_ensure
     context 'with nodejs_package_ensure set to present' do
       let :params do
@@ -747,6 +815,31 @@ describe 'nodejs', type: :class do
       }
     end
 
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('nodejs')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs package resource should not be present' do
+        is_expected.not_to contain_package('nodejs')
+      end
+    end
+
     # nodejs_package_ensure
     context 'with nodejs_package_ensure set to present' do
       let :params do
@@ -781,6 +874,32 @@ describe 'nodejs', type: :class do
           'name' => 'FreeBSD'
         }
       }
+    end
+
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('www/node')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs and dev package resources should not be present' do
+        is_expected.not_to contain_package('www/node')
+        is_expected.not_to contain_package('www/node-devel')
+      end
     end
 
     # nodejs_dev_package_ensure
@@ -869,6 +988,31 @@ describe 'nodejs', type: :class do
       }
     end
 
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('node')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs package resource should not be present' do
+        is_expected.not_to contain_package('node')
+      end
+    end
+
     # nodejs_package_ensure
     context 'with nodejs_package_ensure set to present' do
       let :params do
@@ -903,6 +1047,32 @@ describe 'nodejs', type: :class do
           'name' => 'Darwin'
         }
       }
+    end
+
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('nodejs')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs and dev package resources should not be present' do
+        is_expected.not_to contain_package('nodejs')
+        is_expected.not_to contain_package('nodejs-devel')
+      end
     end
 
     # nodejs_dev_package_ensure
@@ -1012,6 +1182,31 @@ describe 'nodejs', type: :class do
       }
     end
 
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('nodejs')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs package resource should not be present' do
+        is_expected.not_to contain_package('nodejs')
+      end
+    end
+
     # nodejs_package_ensure
     context 'with nodejs_package_ensure set to present' do
       let :params do
@@ -1071,6 +1266,31 @@ describe 'nodejs', type: :class do
           'name' => 'Gentoo'
         }
       }
+    end
+
+    # manage_nodejs_package
+    context 'and manage_nodejs_package set to true' do
+      let :params do
+        {
+          manage_nodejs_package: true
+        }
+      end
+
+      it 'the nodejs package resource should be present' do
+        is_expected.to contain_package('net-libs/nodejs')
+      end
+    end
+
+    context 'and manage_nodejs_package set to false' do
+      let :params do
+        {
+          manage_nodejs_package: false
+        }
+      end
+
+      it 'the nodejs package resource should not be present' do
+        is_expected.not_to contain_package('net-libs/nodejs')
+      end
     end
 
     # nodejs_package_ensure
@@ -1137,6 +1357,27 @@ describe 'nodejs', type: :class do
         {
           manage_package_repo: true
         }
+      end
+
+      context 'and manage_nodejs_package set to true' do
+        let :params do
+          default_params.merge!(manage_nodejs_package: true)
+        end
+
+        it 'the nodejs package resource should be present' do
+          is_expected.to contain_package('nodejs')
+        end
+      end
+
+      context 'and manage_nodejs_package set to false' do
+        let :params do
+          default_params.merge!(manage_nodejs_package: false)
+        end
+
+        it 'the nodejs and dev package resources should not be present' do
+          is_expected.not_to contain_package('nodejs')
+          is_expected.not_to contain_package('nodejs-devel')
+        end
       end
 
       context 'and repo_class set to ::nodejs::repo::nodesource' do


### PR DESCRIPTION
Defaults to true. This allows for using this module without managing the nodejs package. The use case for this is where you want to use the npm package provider in this module, but otherwise have no need for directly installing nodejs. This patch allows for expressing that use case in your puppet code.