### PR TITLE
Drop EL6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,6 @@ that were available on 2017-11-29:
 * Ubuntu 16.04 (Xenial) ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Ubuntu 16.10 (Yakkety) ```0.12``` ```4.x``` ```6.x``` ```7.x``` ```8.x```
 * Ubuntu 17.10 (Artful) ```4.x``` ```6.x``` ```8.x``` ```9.x```
-* RHEL/CentOS 6 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * RHEL/CentOS 7 ```0.10``` ```0.12``` ```4.x``` ```5.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
 * Amazon Linux - See RHEL/CentOS 7
 * Fedora 25 ```4.x``` ```6.x``` ```7.x``` ```8.x``` ```9.x```
@@ -520,8 +519,8 @@ this with the package_provider parameter to use an alternative
 
 This module has received limited testing on:
 
-* CentOS/RHEL 6/7/8
-* Debian 8
+* CentOS/RHEL 7/8
+* Debian 9/10
 * Ubuntu 16.04/18.04/20.04
 
 The following platforms should also work, but have not been tested:
@@ -529,7 +528,6 @@ The following platforms should also work, but have not been tested:
 * Amazon Linux
 * Archlinux
 * Darwin
-* Debian 9
 * Fedora
 * FreeBSD
 * Gentoo
@@ -544,7 +542,7 @@ This modules uses `puppetlabs-apt` for the management of the NodeSource
 repository. If using an operating system of the Debian-based family, you will
 need to ensure that `puppetlabs-apt` version 4.4.0 or above is installed.
 
-If using CentOS/RHEL 6/7 and you wish to install Node.js from EPEL rather
+If using CentOS/RHEL 7 and you wish to install Node.js from EPEL rather
 than from the NodeSource repository, you will need to ensure `puppet-epel` is
 installed and is applied before this module.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,7 +78,7 @@ class nodejs::params {
       $package_provider          = undef
     }
     'RedHat': {
-      if $facts['os']['release']['major'] =~ /^[678]$/ {
+      if $facts['os']['release']['major'] =~ /^[78]$/ {
         $manage_package_repo       = true
         $nodejs_debug_package_name = 'nodejs-debuginfo'
         $nodejs_dev_package_name   = 'nodejs-devel'

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -12,7 +12,7 @@ class nodejs::repo::nodesource {
 
   case $facts['os']['family'] {
     'RedHat': {
-      if $facts['os']['release']['major'] =~ /^[678]$/ {
+      if $facts['os']['release']['major'] =~ /^[78]$/ {
         $dist_version = $facts['os']['release']['major']
         $name_string  = "Enterprise Linux ${dist_version}"
       }

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -19,7 +18,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -27,7 +25,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -35,7 +32,6 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -312,11 +312,11 @@ describe 'nodejs', type: :class do
     end
   end
 
-  ['6.0', '7.0', '27'].each do |operatingsystemrelease|
+  ['7.0', '27'].each do |operatingsystemrelease|
     osversions = operatingsystemrelease.split('.')
     operatingsystemmajrelease = osversions[0]
 
-    if operatingsystemrelease =~ %r{^[6-7]\.(\d+)}
+    if operatingsystemmajrelease == '7'
       operatingsystem     = 'CentOS'
       dist_type           = 'el'
       repo_baseurl        = "https://rpm.nodesource.com/pub_12.x/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"


### PR DESCRIPTION
Current acceptance tests are failing and it's going EOL soon.

Included in https://github.com/voxpupuli/puppet-nodejs/pull/437.