### PR TITLE
Disable failovermethod in yumrepo on EL8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,9 @@
 fixtures:
   repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
-    "portage": "git://github.com/gentoo/puppet-portage.git"
-    "chocolatey": "git://github.com/puppetlabs/puppetlabs-chocolatey.git"
+    "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "apt": "https://github.com/puppetlabs/puppetlabs-apt.git"
+    "portage": "https://github.com/gentoo/puppet-portage.git"
+    "chocolatey": "https://github.com/puppetlabs/puppetlabs-chocolatey.git"
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/manifests/repo/nodesource/yum.pp
+++ b/manifests/repo/nodesource/yum.pp
@@ -16,6 +16,11 @@ class nodejs::repo::nodesource::yum {
     default => '0',
   }
 
+  $yum_failovermethod = (versioncmp($facts['os']['release']['major'], '8') >= 0 and $priority == 'absent') ? {
+    true    => 'absent',
+    default => 'priority',
+  }
+
   if ($ensure == 'present') {
     if $facts['os']['release']['major'] == '8' {
       file { 'dnf_module':
@@ -32,7 +37,7 @@ class nodejs::repo::nodesource::yum {
       descr          => $descr,
       baseurl        => $baseurl,
       enabled        => '1',
-      failovermethod => 'priority',
+      failovermethod => $yum_failovermethod,
       gpgkey         => 'file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL',
       gpgcheck       => '1',
       priority       => $priority,
@@ -46,7 +51,7 @@ class nodejs::repo::nodesource::yum {
       descr          => $source_descr,
       baseurl        => $source_baseurl,
       enabled        => $yum_source_enabled,
-      failovermethod => 'priority',
+      failovermethod => $yum_failovermethod,
       gpgkey         => 'file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL',
       gpgcheck       => '1',
       priority       => $priority,

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,6 @@
+# Facter < 4 needs lsb-release for os.distro.codename
+if versioncmp($facts['facterversion'], '4.0.0') < 0 and $facts['os']['family'] == 'Debian' {
+  package { 'lsb-release':
+    ensure => 'installed',
+  }
+}


### PR DESCRIPTION
#### Pull Request (PR) description
fix yumrepo-format for DNF (EL8 and newer)

#### This Pull Request (PR) fixes the following issues
failovermethod is not supported by DNF, so remove that line completly on
EL8 (and newer) as long as $priority is unset too.