### PR TITLE
Replace PSON parsing with JSON parsing as PSON is deprecated in Puppet 8

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -18,9 +18,9 @@ Puppet::Type.type(:package).provide :npm, parent: Puppet::Provider::Package do
     Puppet.debug("Warning: npm list --json exited with code #{output.exitstatus}") if output.exitstatus != 0
     begin
       # ignore any npm output lines to be a bit more robust
-      output = PSON.parse(output.lines.select { |l| l =~ %r{^((?!^npm).*)$} }.join("\n"), max_nesting: 100)
+      output = JSON.parse(output.lines.select { |l| l =~ %r{^((?!^npm).*)$} }.join("\n"), max_nesting: 100)
       @npmlist = output['dependencies'] || {}
-    rescue PSON::ParserError => e
+    rescue JSON::ParserError => e
       Puppet.debug("Error: npm list --json command error #{e.message}")
       @npmlist = {}
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Replace PSON parsing with JSON parsing as PSON is deprecated in Puppet 8
