### PR TITLE
Don't do `nodejs::install` when `manage_package_repo` is set to `false`.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,9 +31,9 @@ class nodejs (
     fail("${module_name}: The manage_package_repo parameter was set to true but no repo_class was provided.")
   }
 
-  contain 'nodejs::install'
-
   if $manage_package_repo {
+    contain 'nodejs::install'
+
     include $repo_class
 
     Class[$repo_class]


### PR DESCRIPTION
#### Pull Request (PR) description

Do not call the `nodejs::install` when `manage_package_repo` is set to `false`.

#### This Pull Request (PR) fixes the following issues

When/if you like to write `/root/.npmrc` yourself, it will fail otherwise as nodejs module also does it:

`Jul 17 10:10:25 no000010sresd0 puppet-agent[31736]: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: File[/root/.npmrc] is already declared at (file: /etc/puppetlabs/code/vcs/ops/ops_master/external-modules/nodejs/manifests/install.pp, line: 55); cannot redeclare (file: /etc/puppetlabs/code/vcs/devops/devops_master/modules/moller/manifests/modules/node.pp, line: 42) (file: /etc/puppetlabs/code/vcs/devops/devops_master/modules/moller/manifests/modules/node.pp, line: 42, column: 2) (file: /etc/puppetlabs/code/vcs/devops/devops_master/modules/moller/manifests/modules/mollerservice.pp, line: 85) on node no000010sresd0.moller.local`