### PR TITLE
only ensure real npm packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,9 +45,17 @@ class nodejs::install {
 
   # npm
   if $nodejs::npm_package_name and $nodejs::npm_package_name != false {
+    # the nodesource nodejs packages provide "npm" which makes Puppet
+    # try to uninstall them again
+    if $nodejs::npm_package_ensure == absent and $nodejs::manage_package_repo == true and $nodejs::repo_class == 'nodejs::repo::nodesource' {
+      $allow_virtual = false
+    } else {
+      $allow_virtual = undef
+    }
     package { $nodejs::npm_package_name:
-      ensure => $nodejs::npm_package_ensure,
-      tag    => 'nodesource_repo',
+      ensure        => $nodejs::npm_package_ensure,
+      allow_virtual => $allow_virtual,
+      tag           => 'nodesource_repo',
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class nodejs::params {
       $nodejs_dev_package_name   = 'nodejs-devel'
       $nodejs_dev_package_ensure = 'absent'
       $nodejs_package_name       = 'nodejs'
-      $npm_package_ensure        = 'present'
+      $npm_package_ensure        = 'absent'
       $npm_package_name          = 'npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = 'nodejs::repo::nodesource'


### PR DESCRIPTION
nodesource's `nodejs` packages have `Provides: npm` which means that when we try to `ensure => absent` the `npm` package, it really removes the `nodejs` package we want.

by setting `allow_virtual => false` we ensure that we only remove real packages.

Fixes: 160ea93dbc6f6633d01f0a078541bbad21ad93ba

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
