### PR TITLE
replace repo_url_suffix with repo_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ rather than 20.x on Debian/RHEL platforms:
 
 ```puppet
 class { 'nodejs':
-  repo_url_suffix => '21.x',
+  repo_version => '21',
 }
 ```
 
-See the `repo_url_suffix` parameter entry below for possible values.
+See the `repo_version` parameter entry below for possible values.
 
 ## Usage
 
@@ -91,7 +91,7 @@ class { '::nodejs':
 ### Upgrades
 
 The parameter `nodejs_package_ensure` defaults to `installed`. Changing the
-`repo_url_suffix` will not result in a new version being installed. Changing
+`repo_version` will not result in a new version being installed. Changing
 the `nodejs_package_ensure` parameter should provide the desired effect.
 
 For example:
@@ -99,7 +99,7 @@ For example:
 ```puppet
 # Upgrade from nodejs 5.x to 6.x
 class { 'nodejs':
-  repo_url_suffix       => '6.x',
+  repo_version          => '6',
   nodejs_package_ensure => '6.12.2',
 }
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class nodejs (
   $repo_proxy_password                                 = $nodejs::params::repo_proxy_password,
   $repo_proxy_username                                 = $nodejs::params::repo_proxy_username,
   Optional[String] $repo_release                       = $nodejs::params::repo_release,
-  $repo_url_suffix                                     = $nodejs::params::repo_url_suffix,
+  String[1] $repo_version                              = $nodejs::params::repo_version,
   Array $use_flags                                     = $nodejs::params::use_flags,
   Optional[String] $package_provider                   = $nodejs::params::package_provider,
 ) inherits nodejs::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,9 +11,9 @@ class nodejs::params {
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
   $repo_release                = undef
-  $repo_url_suffix             = ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') ? {
-    true    => '16.x',
-    default => '20.x',
+  $repo_version                = ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') ? {
+    true    => '16',
+    default => '20',
   }
   $use_flags                   = ['npm', 'snapshot']
 

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -8,7 +8,8 @@ class nodejs::repo::nodesource {
   $proxy_password = $nodejs::repo_proxy_password
   $proxy_username = $nodejs::repo_proxy_username
   $release        = $nodejs::repo_release
-  $url_suffix     = $nodejs::repo_url_suffix
+
+  $url_suffix     = "${nodejs::repo_version}.x"
 
   case $facts['os']['family'] {
     'RedHat': {

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -134,9 +134,9 @@ describe 'nodejs', type: :class do
           end
         end
 
-        context 'and repo_url_suffix set to 9.x' do
+        context 'and repo_version set to 9' do
           let :params do
-            default_params.merge!(repo_url_suffix: '9.x')
+            default_params.merge!(repo_version: '9')
           end
 
           it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_9.x' do
@@ -372,9 +372,9 @@ describe 'nodejs', type: :class do
           end
         end
 
-        context 'and repo_url_suffix set to 5.x' do
+        context 'and repo_version set to 5' do
           let :params do
-            default_params.merge!(repo_url_suffix: '5.x')
+            default_params.merge!(repo_version: '5')
           end
 
           it "the yum nodesource repo resource should contain baseurl = https://rpm.nodesource.com/pub_5.x/#{dist_type}/#{operatingsystemmajrelease}/$basearch" do


### PR DESCRIPTION
the fact that the version is the suffix of the URL is an implementation detail of the nodesource repository, which shouldn't leak to the consumers of the module

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
