### PR TITLE
(Implicitly) use `apt::keyring` instead of `apt::key` for APT source

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -9,7 +9,7 @@ class nodejs::repo::nodesource::apt {
   if ($ensure != 'absent') {
     apt::source { 'nodesource':
       key      => {
-        'name'   => 'nodesource-repo.gpg.key',
+        'name'   => 'nodesource-repo.gpg.key.asc',
         'source' => 'https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key',
       },
       location => "https://deb.nodesource.com/node_${url_suffix}",


### PR DESCRIPTION
#### Pull Request (PR) description
As Debian 13 removed apt-key, the module does not work when specifying the key ID. Switching to using the gpg key as a keyring fixes this.

#### This Pull Request (PR) fixes the following issues
Not reported.